### PR TITLE
Graphql file names

### DIFF
--- a/src/client/modules/counter/containers/Counter.jsx
+++ b/src/client/modules/counter/containers/Counter.jsx
@@ -8,7 +8,7 @@ import CounterView from '../components/CounterView';
 
 import AMOUNT_QUERY from '../graphql/getCount.graphql';
 import ADD_COUNT_MUTATION from '../graphql/addCount.graphql';
-import COUNT_SUBSCRIPTION from '../graphql/countUpdated.graphql';
+import COUNT_SUBSCRIPTION from '../graphql/updateCount.graphql';
 
 class Counter extends React.Component {
   constructor(props) {
@@ -39,7 +39,7 @@ class Counter extends React.Component {
       variables: {},
       updateQuery: (
         prev,
-        { subscriptionData: { data: { countUpdated: { amount } } } }
+        { subscriptionData: { data: { updateCount: { amount } } } }
       ) => {
         return update(prev, {
           count: {

--- a/src/client/modules/counter/containers/Counter.spec.js
+++ b/src/client/modules/counter/containers/Counter.spec.js
@@ -2,7 +2,7 @@ import chai from 'chai';
 import { step } from 'mocha-steps';
 
 import Renderer from '../../../../client/testHelpers/Renderer';
-import COUNT_SUBSCRIBE from '../graphql/countUpdated.graphql';
+import COUNT_SUBSCRIBE from '../graphql/updateCount.graphql';
 
 chai.should();
 
@@ -68,7 +68,7 @@ describe('Counter example UI works', () => {
   step('Updates counter on data from subscription', () => {
     const subscription = renderer.getSubscriptions(COUNT_SUBSCRIBE)[0];
     subscription(null, {
-      countUpdated: { amount: SUBSCRIPTION_VALUE, __typename: 'Count' }
+      updateCount: { amount: SUBSCRIPTION_VALUE, __typename: 'Count' }
     });
     content
       .text()

--- a/src/client/modules/counter/graphql/countUpdated.graphql
+++ b/src/client/modules/counter/graphql/countUpdated.graphql
@@ -1,5 +1,0 @@
-subscription onCountUpdated {
-    countUpdated {
-        amount
-    }
-}

--- a/src/client/modules/counter/graphql/updateCount.graphql
+++ b/src/client/modules/counter/graphql/updateCount.graphql
@@ -1,0 +1,5 @@
+subscription onUpdateCount {
+    updateCount {
+        amount
+    }
+}

--- a/src/client/modules/post/containers/Post.jsx
+++ b/src/client/modules/post/containers/Post.jsx
@@ -6,7 +6,7 @@ import update from 'immutability-helper';
 import PostList from '../components/PostList';
 
 import POSTS_QUERY from '../graphql/getPosts.graphql';
-import POSTS_SUBSCRIPTION from '../graphql/postsUpdated.graphql';
+import POSTS_SUBSCRIPTION from '../graphql/updatePosts.graphql';
 import POST_DELETE from '../graphql/deletePost.graphql';
 
 export function AddPost(prev, node) {
@@ -91,7 +91,7 @@ class Post extends React.Component {
       variables: { endCursor },
       updateQuery: (
         prev,
-        { subscriptionData: { data: { postsUpdated: { mutation, node } } } }
+        { subscriptionData: { data: { updatePosts: { mutation, node } } } }
       ) => {
         let newResult = prev;
 

--- a/src/client/modules/post/containers/Post.spec.js
+++ b/src/client/modules/post/containers/Post.spec.js
@@ -3,9 +3,9 @@ import { step } from 'mocha-steps';
 import _ from 'lodash';
 
 import Renderer from '../../../../client/testHelpers/Renderer';
-import POSTS_SUBSCRIPTION from '../graphql/postsUpdated.graphql';
-import POST_SUBSCRIPTION from '../graphql/postUpdated.graphql';
-import COMMENT_SUBSCRIPTION from '../graphql/commentUpdated.graphql';
+import POSTS_SUBSCRIPTION from '../graphql/updatePosts.graphql';
+import POST_SUBSCRIPTION from '../graphql/updatePost.graphql';
+import COMMENT_SUBSCRIPTION from '../graphql/updateComment.graphql';
 
 const createNode = id => ({
   id: `${id}`,
@@ -101,7 +101,7 @@ describe('Posts and comments example UI works', () => {
   step('Updates post list on post delete from subscription', () => {
     const subscription = renderer.getSubscriptions(POSTS_SUBSCRIPTION)[0];
     subscription(null, {
-      postsUpdated: {
+      updatePosts: {
         mutation: 'DELETED',
         node: createNode(2),
         __typename: 'UpdatePostPayload'
@@ -117,7 +117,7 @@ describe('Posts and comments example UI works', () => {
     subscription(
       null,
       _.cloneDeep({
-        postsUpdated: {
+        updatePosts: {
           mutation: 'CREATED',
           node: createNode(2),
           __typename: 'UpdatePostPayload'
@@ -170,7 +170,7 @@ describe('Posts and comments example UI works', () => {
   step('Updates post form on post updated from subscription', () => {
     const subscription = renderer.getSubscriptions(POST_SUBSCRIPTION)[0];
     subscription(null, {
-      postUpdated: {
+      updatePost: {
         id: '3',
         title: 'Post title 203',
         content: 'Post content 204',
@@ -242,7 +242,7 @@ describe('Posts and comments example UI works', () => {
   step('Updates comment form on comment added got from subscription', () => {
     const subscription = renderer.getSubscriptions(COMMENT_SUBSCRIPTION)[0];
     subscription(null, {
-      commentUpdated: {
+      updateComment: {
         mutation: 'CREATED',
         id: 3003,
         postId: 3,
@@ -261,7 +261,7 @@ describe('Posts and comments example UI works', () => {
   step('Updates comment form on comment deleted got from subscription', () => {
     const subscription = renderer.getSubscriptions(COMMENT_SUBSCRIPTION)[0];
     subscription(null, {
-      commentUpdated: {
+      updateComment: {
         mutation: 'DELETED',
         id: 3003,
         postId: 3,

--- a/src/client/modules/post/containers/PostComments.jsx
+++ b/src/client/modules/post/containers/PostComments.jsx
@@ -10,7 +10,7 @@ import PostCommentsView from '../components/PostCommentsView';
 import COMMENT_ADD from '../graphql/addComment.graphql';
 import COMMENT_EDIT from '../graphql/editComment.graphql';
 import COMMENT_DELETE from '../graphql/deleteComment.graphql';
-import COMMENT_SUBSCRIPTION from '../graphql/commentUpdated.graphql';
+import COMMENT_SUBSCRIPTION from '../graphql/updateComment.graphql';
 
 function AddComment(prev, node) {
   // ignore if duplicate
@@ -74,7 +74,7 @@ class PostComments extends React.Component {
       updateQuery: (
         prev,
         {
-          subscriptionData: { data: { commentUpdated: { mutation, id, node } } }
+          subscriptionData: { data: { updateComment: { mutation, id, node } } }
         }
       ) => {
         let newResult = prev;

--- a/src/client/modules/post/containers/PostEdit.jsx
+++ b/src/client/modules/post/containers/PostEdit.jsx
@@ -8,7 +8,7 @@ import { AddPost } from './Post';
 import POST_QUERY from '../graphql/getPost.graphql';
 import POST_ADD from '../graphql/addPost.graphql';
 import POST_EDIT from '../graphql/editPost.graphql';
-import POST_SUBSCRIPTION from '../graphql/postUpdated.graphql';
+import POST_SUBSCRIPTION from '../graphql/updatePost.graphql';
 
 class PostEdit extends React.Component {
   constructor(props) {

--- a/src/client/modules/post/graphql/postUpdated.graphql
+++ b/src/client/modules/post/graphql/postUpdated.graphql
@@ -1,7 +1,0 @@
-#import "./post.graphql"
-
-subscription onPostUpdated($id: Int!) {
-    postUpdated(id: $id) {
-        ... PostInfo
-    }
-}

--- a/src/client/modules/post/graphql/updateComment.graphql
+++ b/src/client/modules/post/graphql/updateComment.graphql
@@ -1,7 +1,7 @@
 #import "./comment.graphql"
 
-subscription onCommentUpdated($postId: Int!) {
-    commentUpdated(postId: $postId) {
+subscription onUpdateComment($postId: Int!) {
+    updateComment(postId: $postId) {
         mutation
         id
         postId

--- a/src/client/modules/post/graphql/updatePost.graphql
+++ b/src/client/modules/post/graphql/updatePost.graphql
@@ -1,0 +1,7 @@
+#import "./post.graphql"
+
+subscription onUpdatePost($id: Int!) {
+    updatePost(id: $id) {
+        ... PostInfo
+    }
+}

--- a/src/client/modules/post/graphql/updatePosts.graphql
+++ b/src/client/modules/post/graphql/updatePosts.graphql
@@ -1,7 +1,7 @@
 #import "./post.graphql"
 
-subscription onPostUpdated($endCursor: Int!) {
-    postsUpdated(endCursor: $endCursor) {
+subscription onUpdatePost($endCursor: Int!) {
+    updatePosts(endCursor: $endCursor) {
         mutation
         node {
             ... PostInfo

--- a/src/server/modules/counter/Counter.spec.js
+++ b/src/server/modules/counter/Counter.spec.js
@@ -5,7 +5,7 @@ import { getServer, getApollo } from '../../testHelpers/integrationSetup';
 
 import COUNT_GET_QUERY from '../../../client/modules/counter/graphql/getCount.graphql';
 import COUNT_ADD_MUTATION from '../../../client/modules/counter/graphql/addCount.graphql';
-import COUNT_SUBSCRIPTION from '../../../client/modules/counter/graphql/countUpdated.graphql';
+import COUNT_SUBSCRIPTION from '../../../client/modules/counter/graphql/updateCount.graphql';
 
 describe('Counter example API works', () => {
   let server, apollo;
@@ -55,7 +55,7 @@ describe('Counter example API works', () => {
       .subscribe({
         next(data) {
           data.should.deep.equal({
-            countUpdated: { amount: 8, __typename: 'Count' }
+            updateCount: { amount: 8, __typename: 'Count' }
           });
           done();
         }

--- a/src/server/modules/counter/resolvers.js
+++ b/src/server/modules/counter/resolvers.js
@@ -12,14 +12,14 @@ export default pubsub => ({
       const count = await context.Count.getCount();
 
       pubsub.publish(COUNT_UPDATED_TOPIC, {
-        countUpdated: { amount: count.amount }
+        updateCount: { amount: count.amount }
       });
 
       return count;
     }
   },
   Subscription: {
-    countUpdated: {
+    updateCount: {
       subscribe: () => pubsub.asyncIterator(COUNT_UPDATED_TOPIC)
     }
   }

--- a/src/server/modules/counter/resolvers.js
+++ b/src/server/modules/counter/resolvers.js
@@ -1,4 +1,4 @@
-const COUNT_UPDATED_TOPIC = 'count_updated';
+const UPDATE_COUNT = 'update_count';
 
 export default pubsub => ({
   Query: {
@@ -11,7 +11,7 @@ export default pubsub => ({
       await context.Count.addCount(amount);
       const count = await context.Count.getCount();
 
-      pubsub.publish(COUNT_UPDATED_TOPIC, {
+      pubsub.publish(UPDATE_COUNT, {
         updateCount: { amount: count.amount }
       });
 
@@ -20,7 +20,7 @@ export default pubsub => ({
   },
   Subscription: {
     updateCount: {
-      subscribe: () => pubsub.asyncIterator(COUNT_UPDATED_TOPIC)
+      subscribe: () => pubsub.asyncIterator(UPDATE_COUNT)
     }
   }
 });

--- a/src/server/modules/counter/schema.graphqls
+++ b/src/server/modules/counter/schema.graphqls
@@ -19,5 +19,5 @@ extend type Mutation {
 
 extend type Subscription {
   # Subscription fired when anyone increases counter
-  countUpdated: Count
+  updateCount: Count
 }

--- a/src/server/modules/post/Post.spec.js
+++ b/src/server/modules/post/Post.spec.js
@@ -7,7 +7,7 @@ import POST_GET from '../../../client/modules/post/graphql/getPost.graphql';
 import POST_ADD from '../../../client/modules/post/graphql/addPost.graphql';
 import POST_EDIT from '../../../client/modules/post/graphql/editPost.graphql';
 import POST_DELETE from '../../../client/modules/post/graphql/deletePost.graphql';
-import POSTS_SUBSCRIPTION from '../../../client/modules/post/graphql/postsUpdated.graphql';
+import POSTS_SUBSCRIPTION from '../../../client/modules/post/graphql/updatePosts.graphql';
 
 describe('Post and comments example API works', () => {
   let apollo;
@@ -93,7 +93,7 @@ describe('Post and comments example API works', () => {
       .subscribe({
         next(data) {
           expect(data).to.deep.equal({
-            postsUpdated: {
+            updatePosts: {
               mutation: 'CREATED',
               node: {
                 id: 21,
@@ -149,7 +149,7 @@ describe('Post and comments example API works', () => {
       .subscribe({
         next(data) {
           expect(data).to.deep.equal({
-            postsUpdated: {
+            updatePosts: {
               mutation: 'UPDATED',
               node: {
                 id: 21,
@@ -199,7 +199,7 @@ describe('Post and comments example API works', () => {
       .subscribe({
         next(data) {
           expect(data).to.deep.equal({
-            postsUpdated: {
+            updatePosts: {
               mutation: 'DELETED',
               node: {
                 id: 21,

--- a/src/server/modules/post/resolvers.js
+++ b/src/server/modules/post/resolvers.js
@@ -53,7 +53,7 @@ export default pubsub => ({
       const post = await context.Post.getPost(id);
       // publish for post list
       pubsub.publish(POSTS_UPDATED_TOPIC, {
-        postsUpdated: {
+        updatePosts: {
           mutation: 'CREATED',
           id,
           node: post
@@ -67,7 +67,7 @@ export default pubsub => ({
       if (isDeleted) {
         // publish for post list
         pubsub.publish(POSTS_UPDATED_TOPIC, {
-          postsUpdated: {
+          updatePosts: {
             mutation: 'DELETED',
             id,
             node: post
@@ -83,14 +83,14 @@ export default pubsub => ({
       const post = await context.Post.getPost(input.id);
       // publish for post list
       pubsub.publish(POSTS_UPDATED_TOPIC, {
-        postsUpdated: {
+        updatePosts: {
           mutation: 'UPDATED',
           id: post.id,
           node: post
         }
       });
       // publish for edit post page
-      pubsub.publish(POST_UPDATED_TOPIC, { postUpdated: post });
+      pubsub.publish(POST_UPDATED_TOPIC, { updatePost: post });
       return post;
     },
     async addComment(obj, { input }, context) {
@@ -98,7 +98,7 @@ export default pubsub => ({
       const comment = await context.Post.getComment(id);
       // publish for edit post page
       pubsub.publish(COMMENT_UPDATED_TOPIC, {
-        commentUpdated: {
+        updateComment: {
           mutation: 'CREATED',
           id: comment.id,
           postId: input.postId,
@@ -111,7 +111,7 @@ export default pubsub => ({
       await context.Post.deleteComment(id);
       // publish for edit post page
       pubsub.publish(COMMENT_UPDATED_TOPIC, {
-        commentUpdated: {
+        updateComment: {
           mutation: 'DELETED',
           id,
           postId,
@@ -125,7 +125,7 @@ export default pubsub => ({
       const comment = await context.Post.getComment(input.id);
       // publish for edit post page
       pubsub.publish(COMMENT_UPDATED_TOPIC, {
-        commentUpdated: {
+        updateComment: {
           mutation: 'UPDATED',
           id: input.id,
           postId: input.postId,
@@ -136,27 +136,27 @@ export default pubsub => ({
     }
   },
   Subscription: {
-    postUpdated: {
+    updatePost: {
       subscribe: withFilter(
         () => pubsub.asyncIterator(POST_UPDATED_TOPIC),
         (payload, variables) => {
-          return payload.postUpdated.id === variables.id;
+          return payload.updatePost.id === variables.id;
         }
       )
     },
-    postsUpdated: {
+    updatePosts: {
       subscribe: withFilter(
         () => pubsub.asyncIterator(POSTS_UPDATED_TOPIC),
         (payload, variables) => {
-          return variables.endCursor <= payload.postsUpdated.id;
+          return variables.endCursor <= payload.updatePosts.id;
         }
       )
     },
-    commentUpdated: {
+    updateComment: {
       subscribe: withFilter(
         () => pubsub.asyncIterator(COMMENT_UPDATED_TOPIC),
         (payload, variables) => {
-          return payload.commentUpdated.postId === variables.postId;
+          return payload.updateComment.postId === variables.postId;
         }
       )
     }

--- a/src/server/modules/post/resolvers.js
+++ b/src/server/modules/post/resolvers.js
@@ -1,8 +1,8 @@
 import { withFilter } from 'graphql-subscriptions';
 
-const POST_UPDATED_TOPIC = 'post_updated';
-const POSTS_UPDATED_TOPIC = 'posts_updated';
-const COMMENT_UPDATED_TOPIC = 'comment_updated';
+const UPDATE_POST = 'update_post';
+const UPDATE_POSTS = 'update_posts';
+const UPDATE_COMMENT = 'update_comment';
 
 export default pubsub => ({
   Query: {
@@ -52,7 +52,7 @@ export default pubsub => ({
       const [id] = await context.Post.addPost(input);
       const post = await context.Post.getPost(id);
       // publish for post list
-      pubsub.publish(POSTS_UPDATED_TOPIC, {
+      pubsub.publish(UPDATE_POSTS, {
         updatePosts: {
           mutation: 'CREATED',
           id,
@@ -66,7 +66,7 @@ export default pubsub => ({
       const isDeleted = await context.Post.deletePost(id);
       if (isDeleted) {
         // publish for post list
-        pubsub.publish(POSTS_UPDATED_TOPIC, {
+        pubsub.publish(UPDATE_POSTS, {
           updatePosts: {
             mutation: 'DELETED',
             id,
@@ -82,7 +82,7 @@ export default pubsub => ({
       await context.Post.editPost(input);
       const post = await context.Post.getPost(input.id);
       // publish for post list
-      pubsub.publish(POSTS_UPDATED_TOPIC, {
+      pubsub.publish(UPDATE_POSTS, {
         updatePosts: {
           mutation: 'UPDATED',
           id: post.id,
@@ -90,14 +90,14 @@ export default pubsub => ({
         }
       });
       // publish for edit post page
-      pubsub.publish(POST_UPDATED_TOPIC, { updatePost: post });
+      pubsub.publish(UPDATE_POST, { updatePost: post });
       return post;
     },
     async addComment(obj, { input }, context) {
       const [id] = await context.Post.addComment(input);
       const comment = await context.Post.getComment(id);
       // publish for edit post page
-      pubsub.publish(COMMENT_UPDATED_TOPIC, {
+      pubsub.publish(UPDATE_COMMENT, {
         updateComment: {
           mutation: 'CREATED',
           id: comment.id,
@@ -110,7 +110,7 @@ export default pubsub => ({
     async deleteComment(obj, { input: { id, postId } }, context) {
       await context.Post.deleteComment(id);
       // publish for edit post page
-      pubsub.publish(COMMENT_UPDATED_TOPIC, {
+      pubsub.publish(UPDATE_COMMENT, {
         updateComment: {
           mutation: 'DELETED',
           id,
@@ -124,7 +124,7 @@ export default pubsub => ({
       await context.Post.editComment(input);
       const comment = await context.Post.getComment(input.id);
       // publish for edit post page
-      pubsub.publish(COMMENT_UPDATED_TOPIC, {
+      pubsub.publish(UPDATE_COMMENT, {
         updateComment: {
           mutation: 'UPDATED',
           id: input.id,
@@ -138,7 +138,7 @@ export default pubsub => ({
   Subscription: {
     updatePost: {
       subscribe: withFilter(
-        () => pubsub.asyncIterator(POST_UPDATED_TOPIC),
+        () => pubsub.asyncIterator(UPDATE_POST),
         (payload, variables) => {
           return payload.updatePost.id === variables.id;
         }
@@ -146,7 +146,7 @@ export default pubsub => ({
     },
     updatePosts: {
       subscribe: withFilter(
-        () => pubsub.asyncIterator(POSTS_UPDATED_TOPIC),
+        () => pubsub.asyncIterator(UPDATE_POSTS),
         (payload, variables) => {
           return variables.endCursor <= payload.updatePosts.id;
         }
@@ -154,7 +154,7 @@ export default pubsub => ({
     },
     updateComment: {
       subscribe: withFilter(
-        () => pubsub.asyncIterator(COMMENT_UPDATED_TOPIC),
+        () => pubsub.asyncIterator(UPDATE_COMMENT),
         (payload, variables) => {
           return payload.updateComment.postId === variables.postId;
         }

--- a/src/server/modules/post/schema.graphqls
+++ b/src/server/modules/post/schema.graphqls
@@ -69,14 +69,14 @@ input EditPostInput {
 # Input for addComment Mutation
 input AddCommentInput {
   content: String!
-  # Needed for commentUpdated Subscription filter
+  # Needed for updateComment Subscription filter
   postId: Int!
 }
 
 # Input for editComment Mutation
 input DeleteCommentInput {
   id: Int!
-  # Needed for commentUpdated Subscription filter
+  # Needed for updateComment Subscription filter
   postId: Int!
 }
 
@@ -84,27 +84,27 @@ input DeleteCommentInput {
 input EditCommentInput {
   id: Int!
   content: String!
-  # Needed for commentUpdated Subscription filter
+  # Needed for updateComment Subscription filter
   postId: Int!
 }
 
 extend type Subscription {
   # Subscription for when editing a post
-  postUpdated(id: Int!): Post
+  updatePost(id: Int!): Post
   # Subscription for post list
-  postsUpdated(endCursor: Int!): UpdatePostPayload
+  updatePosts(endCursor: Int!): UpdatePostPayload
   # Subscription for comments
-  commentUpdated(postId: Int!): UpdateCommentPayload
+  updateComment(postId: Int!): UpdateCommentPayload
 }
 
-# Payload for postsUpdated Subscription
+# Payload for updatePosts Subscription
 type UpdatePostPayload {
   mutation: String!
   id: Int!
   node: Post
 }
 
-# Payload for commentUpdated Subscription
+# Payload for updateComment Subscription
 type UpdateCommentPayload {
   mutation: String!
   id: Int


### PR DESCRIPTION
Since we use action (verb) in the beginning for (get, add, delete) query/mutations, it looked odd to me that we use the module name in the beginning for subscription/update graphql filenames and actions.

Let me know if this change makes sense to you guys.