### PR TITLE
extract pubsub into separate file

### DIFF
--- a/src/server/api/pubsub.js
+++ b/src/server/api/pubsub.js
@@ -1,0 +1,8 @@
+import { addApolloLogging } from 'apollo-logger';
+import { PubSub } from 'graphql-subscriptions';
+
+import settings from '../../../settings';
+
+const pubsub = settings.apolloLogging ? addApolloLogging(new PubSub()) : new PubSub();
+
+export default pubsub;

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1,13 +1,9 @@
 import { makeExecutableSchema, addErrorLoggingToSchema } from 'graphql-tools';
-import { addApolloLogging } from 'apollo-logger';
-import { PubSub } from 'graphql-subscriptions';
 
 import rootSchemaDef from './rootSchema.graphqls';
 import modules from '../modules';
+import pubsub from './pubsub';
 import log from '../../common/log';
-import settings from '../../../settings';
-
-export const pubsub = settings.apolloLogging ? addApolloLogging(new PubSub()) : new PubSub();
 
 const executableSchema = makeExecutableSchema({
   typeDefs: [rootSchemaDef].concat(modules.schemas),


### PR DESCRIPTION
@vlasenko In one of my projects I need to import `pubsub` to a file that gets called before `modules` exist. So for this to work I needed to move `pubsub` into a separate file and then include it back into `schema.js`.

Would this be something we can add to `master` or should I keep changes like this in my separate branch, that I then use to up-merge?