### PR TITLE
Fix issue #450

### DIFF
--- a/src/server/database/migrations/002_user.js
+++ b/src/server/database/migrations/002_user.js
@@ -47,9 +47,9 @@ exports.up = function(knex, Promise) {
 
 exports.down = function(knex, Promise) {
   return Promise.all([
-    knex.schema.dropTable('user'),
     knex.schema.dropTable('auth_local'),
     knex.schema.dropTable('auth_certificate'),
-    knex.schema.dropTable('auth_facebook')
+    knex.schema.dropTable('auth_facebook'),
+    knex.schema.dropTable('user')
   ]);
 };

--- a/src/server/database/migrations/003_post.js
+++ b/src/server/database/migrations/003_post.js
@@ -22,5 +22,5 @@ exports.up = function(knex, Promise) {
 };
 
 exports.down = function(knex, Promise) {
-  return Promise.all([knex.schema.dropTable('post'), knex.schema.dropTable('comment')]);
+  return Promise.all([knex.schema.dropTable('comment'), knex.schema.dropTable('post')]);
 };


### PR DESCRIPTION
When using a Postgres db, running 'yarn rollback' cannot revert back to
pre-migration state due to table dependency errors caused by the "user"
and "post" tables.

This commit changes the Promise order within the export.down() functions
for "post" and "user" migration files so that the dependency tables are
dropped first.

Confirmed: rollback for default 'sqlite' database is unaffected by the
change.