### PR TITLE
using distinct count to avoid groupBy

### DIFF
--- a/src/server/modules/post/sql.js
+++ b/src/server/modules/post/sql.js
@@ -39,13 +39,13 @@ export default class Post {
 
   getTotal() {
     return knex('post')
-      .count('id as count')
+      .countDistinct('id as count')
       .first();
   }
 
   getNextPageFlag(id) {
     return knex('post')
-      .count('id as count')
+      .countDistinct('id as count')
       .where('id', '<', id)
       .first();
   }


### PR DESCRIPTION
- Minor fix - Use case: When you have `joins` on the table the `count` will return duplicate rows (causing problem in the totalCount value (pagination))and thus by using `countDistinct` the query will remove duplicate rows without having to use `groupBy`