### PR TITLE
Secure /login and /register route for logged in user

### DIFF
--- a/src/client/modules/user/containers/Auth.jsx
+++ b/src/client/modules/user/containers/Auth.jsx
@@ -79,6 +79,15 @@ AuthNav.propTypes = {
   cookies: PropTypes.instanceOf(Cookies)
 };
 
+const AuthLoggedIn = withCookies(({ cookies, ...rest }) => {
+  return checkAuth(cookies) ? <NavLink {...rest}>{profileName(cookies)}</NavLink> : null;
+});
+
+AuthLoggedIn.propTypes = {
+  component: PropTypes.func,
+  cookies: PropTypes.instanceOf(Cookies)
+};
+
 const AuthLogin = ({ children, cookies, logout }) => {
   return checkAuth(cookies) ? (
     <a href="#" onClick={() => logout()} className="nav-link">
@@ -136,18 +145,6 @@ const AuthLoginWithApollo = withCookies(
   )
 );
 
-const AuthProfile = withCookies(({ cookies }) => {
-  return checkAuth(cookies) ? (
-    <NavLink to="/profile" className="nav-link" activeClassName="active">
-      {profileName(cookies)}
-    </NavLink>
-  ) : null;
-});
-
-AuthProfile.propTypes = {
-  cookies: PropTypes.instanceOf(Cookies)
-};
-
 const AuthRoute = withCookies(({ component: Component, cookies, scope, ...rest }) => {
   return (
     <Route
@@ -164,7 +161,26 @@ AuthRoute.propTypes = {
   cookies: PropTypes.instanceOf(Cookies)
 };
 
+const AuthLoggedInRoute = withCookies(({ component: Component, cookies, redirect, scope, ...rest }) => {
+  return (
+    <Route
+      {...rest}
+      render={props =>
+        checkAuth(cookies, scope) ? <Redirect to={{ pathname: redirect }} /> : <Component {...props} />
+      }
+    />
+  );
+});
+
+AuthLoggedInRoute.propTypes = {
+  component: PropTypes.func,
+  cookies: PropTypes.instanceOf(Cookies),
+  redirect: PropTypes.string,
+  scope: PropTypes.string
+};
+
 export { AuthNav };
-export { AuthProfile };
+export { AuthLoggedIn };
 export { AuthLoginWithApollo as AuthLogin };
 export { AuthRoute };
+export { AuthLoggedInRoute };

--- a/src/client/modules/user/containers/Auth.jsx
+++ b/src/client/modules/user/containers/Auth.jsx
@@ -79,15 +79,6 @@ AuthNav.propTypes = {
   cookies: PropTypes.instanceOf(Cookies)
 };
 
-const AuthLoggedIn = withCookies(({ cookies, ...rest }) => {
-  return checkAuth(cookies) ? <NavLink {...rest}>{profileName(cookies)}</NavLink> : null;
-});
-
-AuthLoggedIn.propTypes = {
-  component: PropTypes.func,
-  cookies: PropTypes.instanceOf(Cookies)
-};
-
 const AuthLogin = ({ children, cookies, logout }) => {
   return checkAuth(cookies) ? (
     <a href="#" onClick={() => logout()} className="nav-link">
@@ -145,6 +136,33 @@ const AuthLoginWithApollo = withCookies(
   )
 );
 
+const AuthProfile = withCookies(({ cookies }) => {
+  return checkAuth(cookies) ? (
+    <NavLink to="/profile" className="nav-link" activeClassName="active">
+      {profileName(cookies)}
+    </NavLink>
+  ) : null;
+});
+
+AuthProfile.propTypes = {
+  cookies: PropTypes.instanceOf(Cookies)
+};
+
+const AuthLoggedIn = withCookies(({ cookies, label, to, ...rest }) => {
+  return checkAuth(cookies) ? (
+    <NavLink to={to} {...rest}>
+      {label}
+    </NavLink>
+  ) : null;
+});
+
+AuthLoggedIn.propTypes = {
+  component: PropTypes.func,
+  cookies: PropTypes.instanceOf(Cookies),
+  label: PropTypes.string,
+  to: PropTypes.string
+};
+
 const AuthRoute = withCookies(({ component: Component, cookies, scope, ...rest }) => {
   return (
     <Route
@@ -182,5 +200,6 @@ AuthLoggedInRoute.propTypes = {
 export { AuthNav };
 export { AuthLoggedIn };
 export { AuthLoginWithApollo as AuthLogin };
+export { AuthProfile };
 export { AuthRoute };
 export { AuthLoggedInRoute };

--- a/src/client/modules/user/index.web.jsx
+++ b/src/client/modules/user/index.web.jsx
@@ -10,7 +10,7 @@ import ForgotPassword from './containers/ForgotPassword';
 import ResetPassword from './containers/ResetPassword';
 import reducers from './reducers';
 
-import { AuthRoute, AuthNav, AuthLogin, AuthProfile } from './containers/Auth';
+import { AuthRoute, AuthLoggedInRoute, AuthNav, AuthLogin, AuthLoggedIn } from './containers/Auth';
 
 import Feature from '../connector';
 
@@ -44,8 +44,8 @@ export default new Feature({
     <AuthRoute exact path="/profile" scope="user" component={Profile} />,
     <AuthRoute exact path="/users" scope="admin" component={Users} />,
     <Route exact path="/users/:id" component={UserEdit} />,
-    <Route exact path="/register" component={Register} />,
-    <Route exact path="/login" component={Login} />,
+    <AuthLoggedInRoute exact path="/register" redirect="/profile" component={Register} />,
+    <AuthLoggedInRoute exact path="/login" redirect="/profile" component={Login} />,
     <Route exact path="/forgot-password" component={ForgotPassword} />,
     <Route exact path="/reset-password/:token" component={ResetPassword} />
   ],
@@ -60,7 +60,7 @@ export default new Feature({
   ],
   navItemRight: [
     <MenuItem key="/profile">
-      <AuthProfile />
+      <AuthLoggedIn to="/profile" className="nav-link" activeClassName="active" />
     </MenuItem>,
     <MenuItem key="login">
       <AuthLogin>

--- a/src/client/modules/user/index.web.jsx
+++ b/src/client/modules/user/index.web.jsx
@@ -10,7 +10,7 @@ import ForgotPassword from './containers/ForgotPassword';
 import ResetPassword from './containers/ResetPassword';
 import reducers from './reducers';
 
-import { AuthRoute, AuthLoggedInRoute, AuthNav, AuthLogin, AuthLoggedIn } from './containers/Auth';
+import { AuthRoute, AuthLoggedInRoute, AuthNav, AuthLogin, AuthProfile } from './containers/Auth';
 
 import Feature from '../connector';
 
@@ -46,8 +46,8 @@ export default new Feature({
     <Route exact path="/users/:id" component={UserEdit} />,
     <AuthLoggedInRoute exact path="/register" redirect="/profile" component={Register} />,
     <AuthLoggedInRoute exact path="/login" redirect="/profile" component={Login} />,
-    <Route exact path="/forgot-password" component={ForgotPassword} />,
-    <Route exact path="/reset-password/:token" component={ResetPassword} />
+    <AuthLoggedInRoute exact path="/forgot-password" redirect="/profile" component={ForgotPassword} />,
+    <AuthLoggedInRoute exact path="/reset-password/:token" redirect="/profile" component={ResetPassword} />
   ],
   navItem: [
     <MenuItem key="/users">
@@ -60,7 +60,7 @@ export default new Feature({
   ],
   navItemRight: [
     <MenuItem key="/profile">
-      <AuthLoggedIn to="/profile" className="nav-link" activeClassName="active" />
+      <AuthProfile />
     </MenuItem>,
     <MenuItem key="login">
       <AuthLogin>


### PR DESCRIPTION
Thanks for the awesome boilerplate! In response to #496:
1.  Created an `AuthLoggedInRoute`: Protects any desired routes when the user is already logged in such as _/login_ or _/register_ and redirects to desired location (example: _/profile_).
2. Created an `AuthLoggedIn` navlink: Abstracted version of `AuthProfile`.  Uses minimum `to` and `label` props and I should probably make those required. Would be good to have documentation of it somewhere as I didn't create a sample link and would be happy to if you have a recommendation where. Example: `<AuthLoggedIn to="/profile" label="Profile" className="nav-link" activeClassName="active" />` 

If there's any preferred naming, just let me know and I'd be happy to replace. Cheers!