### PR TITLE
Refactor react comp

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:flowtype/recommended"
- ],
+  ],
   "rules": {
     "no-use-before-define": 0,
     "arrow-body-style": 0,
@@ -14,11 +14,15 @@
     "no-console": 0,
     "react/jsx-key": 0,
     "semi": 2,
-    "prettier/prettier": ["error", {
-      "printWidth": 120,
-      "singleQuote": true,
-      "parser": "babylon"
-    }]
+    "react/sort-comp": 1,
+    "prettier/prettier": [
+      "error",
+      {
+        "printWidth": 120,
+        "singleQuote": true,
+        "parser": "babylon"
+      }
+    ]
   },
   "settings": {
     "import/resolver": {
@@ -42,5 +46,10 @@
     "__PERSIST_GQL__": true,
     "__BACKEND_URL__": true
   },
-  "plugins": ["react", "json", "prettier", "flowtype"]
+  "plugins": [
+    "react",
+    "json",
+    "prettier",
+    "flowtype"
+  ]
 }

--- a/src/client/app/Main.jsx
+++ b/src/client/app/Main.jsx
@@ -157,7 +157,7 @@ class ServerError extends Error {
   }
 }
 
-class Main extends React.Component {
+export default class Main extends React.Component {
   constructor(props) {
     super(props);
     const serverError = window.__SERVER_ERROR__;
@@ -186,5 +186,3 @@ class Main extends React.Component {
     );
   }
 }
-
-export default Main;

--- a/src/client/app/RedBox.jsx
+++ b/src/client/app/RedBox.jsx
@@ -12,13 +12,13 @@ class RedBox extends React.Component {
     error: PropTypes.instanceOf(Error).isRequired
   };
 
-  state = {
-    mapped: false
-  };
-
   constructor(props) {
     super(props);
   }
+
+  state = {
+    mapped: false
+  };
 
   componentDidMount() {
     if (!this.state.mapped) {

--- a/src/client/app/RedBox.jsx
+++ b/src/client/app/RedBox.jsx
@@ -7,7 +7,7 @@ import settings from '../../../settings';
 const format = (fmt, ...args) =>
   fmt.replace(/{(\d+)}/g, (match, number) => (typeof args[number] != 'undefined' ? args[number] : match));
 
-class RedBox extends React.Component {
+export default class RedBox extends React.Component {
   static propTypes = {
     error: PropTypes.instanceOf(Error).isRequired
   };
@@ -127,5 +127,3 @@ const styles = {
     color: 'rgba(255, 255, 255, 0.7)'
   }
 };
-
-export default RedBox;

--- a/src/client/modules/counter/containers/Counter.jsx
+++ b/src/client/modules/counter/containers/Counter.jsx
@@ -11,6 +11,16 @@ import ADD_COUNTER from '../graphql/AddCounter.graphql';
 import COUNTER_SUBSCRIPTION from '../graphql/CounterSubscription.graphql';
 
 class Counter extends React.Component {
+  static defaultProps = {
+    loading: false,
+    subscribeToMore: () => {}
+  };
+
+  static propTypes = {
+    loading: PropTypes.bool.isRequired,
+    subscribeToMore: PropTypes.func.isRequired
+  };
+
   constructor(props) {
     super(props);
 
@@ -53,11 +63,6 @@ class Counter extends React.Component {
     return <CounterView {...this.props} />;
   }
 }
-
-Counter.propTypes = {
-  loading: PropTypes.bool.isRequired,
-  subscribeToMore: PropTypes.func.isRequired
-};
 
 const CounterWithApollo = compose(
   graphql(COUNTER_QUERY, {

--- a/src/client/modules/counter/containers/Counter.jsx
+++ b/src/client/modules/counter/containers/Counter.jsx
@@ -11,11 +11,6 @@ import ADD_COUNTER from '../graphql/AddCounter.graphql';
 import COUNTER_SUBSCRIPTION from '../graphql/CounterSubscription.graphql';
 
 class Counter extends React.Component {
-  static defaultProps = {
-    loading: false,
-    subscribeToMore: () => {}
-  };
-
   static propTypes = {
     loading: PropTypes.bool.isRequired,
     subscribeToMore: PropTypes.func.isRequired
@@ -23,7 +18,6 @@ class Counter extends React.Component {
 
   constructor(props) {
     super(props);
-
     this.subscription = null;
   }
 

--- a/src/client/modules/post/components/PostCommentsView.jsx
+++ b/src/client/modules/post/components/PostCommentsView.jsx
@@ -5,7 +5,31 @@ import { SwipeAction } from '../../common/components/native';
 
 import PostCommentForm from './PostCommentForm';
 
-class PostCommentsView extends React.PureComponent {
+export default class PostCommentsView extends React.PureComponent {
+  static defaultProps = {
+    postId: null,
+    comments: [],
+    comment: {},
+    addComment: () => {},
+    editComment: () => {},
+    deleteComment: () => {},
+    onCommentSelect: () => {},
+    onFormSubmitted: () => {},
+    subscribeToMore: () => {}
+  };
+
+  static propTypes = {
+    postId: PropTypes.number.isRequired,
+    comments: PropTypes.array.isRequired,
+    comment: PropTypes.object,
+    addComment: PropTypes.func.isRequired,
+    editComment: PropTypes.func.isRequired,
+    deleteComment: PropTypes.func.isRequired,
+    onCommentSelect: PropTypes.func.isRequired,
+    onFormSubmitted: PropTypes.func.isRequired,
+    subscribeToMore: PropTypes.func.isRequired
+  };
+
   keyExtractor = item => item.id;
 
   renderItem = ({ item: { id, content } }) => {
@@ -64,18 +88,6 @@ class PostCommentsView extends React.PureComponent {
   }
 }
 
-PostCommentsView.propTypes = {
-  postId: PropTypes.number.isRequired,
-  comments: PropTypes.array.isRequired,
-  comment: PropTypes.object,
-  addComment: PropTypes.func.isRequired,
-  editComment: PropTypes.func.isRequired,
-  deleteComment: PropTypes.func.isRequired,
-  onCommentSelect: PropTypes.func.isRequired,
-  onFormSubmitted: PropTypes.func.isRequired,
-  subscribeToMore: PropTypes.func.isRequired
-};
-
 const styles = StyleSheet.create({
   title: {
     fontSize: 20,
@@ -87,5 +99,3 @@ const styles = StyleSheet.create({
     paddingTop: 10
   }
 });
-
-export default PostCommentsView;

--- a/src/client/modules/post/components/PostCommentsView.jsx
+++ b/src/client/modules/post/components/PostCommentsView.jsx
@@ -6,18 +6,6 @@ import { SwipeAction } from '../../common/components/native';
 import PostCommentForm from './PostCommentForm';
 
 export default class PostCommentsView extends React.PureComponent {
-  static defaultProps = {
-    postId: null,
-    comments: [],
-    comment: {},
-    addComment: () => {},
-    editComment: () => {},
-    deleteComment: () => {},
-    onCommentSelect: () => {},
-    onFormSubmitted: () => {},
-    subscribeToMore: () => {}
-  };
-
   static propTypes = {
     postId: PropTypes.number.isRequired,
     comments: PropTypes.array.isRequired,

--- a/src/client/modules/post/components/PostCommentsView.web.jsx
+++ b/src/client/modules/post/components/PostCommentsView.web.jsx
@@ -4,18 +4,6 @@ import { Table, Button } from '../../common/components/web';
 import PostCommentForm from './PostCommentForm';
 
 export default class PostCommentsView extends React.PureComponent {
-  static defaultProps = {
-    postId: null,
-    comments: [],
-    comment: {},
-    addComment: () => {},
-    editComment: () => {},
-    deleteComment: () => {},
-    onCommentSelect: () => {},
-    onFormSubmitted: () => {},
-    subscribeToMore: () => {}
-  };
-
   static propTypes = {
     postId: PropTypes.number.isRequired,
     comments: PropTypes.array.isRequired,

--- a/src/client/modules/post/components/PostCommentsView.web.jsx
+++ b/src/client/modules/post/components/PostCommentsView.web.jsx
@@ -3,7 +3,31 @@ import PropTypes from 'prop-types';
 import { Table, Button } from '../../common/components/web';
 import PostCommentForm from './PostCommentForm';
 
-class PostCommentsView extends React.PureComponent {
+export default class PostCommentsView extends React.PureComponent {
+  static defaultProps = {
+    postId: null,
+    comments: [],
+    comment: {},
+    addComment: () => {},
+    editComment: () => {},
+    deleteComment: () => {},
+    onCommentSelect: () => {},
+    onFormSubmitted: () => {},
+    subscribeToMore: () => {}
+  };
+
+  static propTypes = {
+    postId: PropTypes.number.isRequired,
+    comments: PropTypes.array.isRequired,
+    comment: PropTypes.object,
+    addComment: PropTypes.func.isRequired,
+    editComment: PropTypes.func.isRequired,
+    deleteComment: PropTypes.func.isRequired,
+    onCommentSelect: PropTypes.func.isRequired,
+    onFormSubmitted: PropTypes.func.isRequired,
+    subscribeToMore: PropTypes.func.isRequired
+  };
+
   hendleEditComment = (id, content) => {
     const { onCommentSelect } = this.props;
     onCommentSelect({ id, content });
@@ -78,17 +102,3 @@ class PostCommentsView extends React.PureComponent {
     );
   }
 }
-
-PostCommentsView.propTypes = {
-  postId: PropTypes.number.isRequired,
-  comments: PropTypes.array.isRequired,
-  comment: PropTypes.object.isRequired,
-  addComment: PropTypes.func.isRequired,
-  editComment: PropTypes.func.isRequired,
-  deleteComment: PropTypes.func.isRequired,
-  onCommentSelect: PropTypes.func.isRequired,
-  onFormSubmitted: PropTypes.func.isRequired,
-  subscribeToMore: PropTypes.func.isRequired
-};
-
-export default PostCommentsView;

--- a/src/client/modules/post/components/PostList.jsx
+++ b/src/client/modules/post/components/PostList.jsx
@@ -5,14 +5,6 @@ import { StyleSheet, FlatList, Text, View } from 'react-native';
 import { SwipeAction } from '../../common/components/native';
 
 export default class PostList extends React.PureComponent {
-  static defaultProps = {
-    loading: false,
-    posts: {},
-    navigation: {},
-    deletePost: () => {},
-    loadMoreRows: () => {}
-  };
-
   static propTypes = {
     loading: PropTypes.bool.isRequired,
     posts: PropTypes.object,

--- a/src/client/modules/post/components/PostList.jsx
+++ b/src/client/modules/post/components/PostList.jsx
@@ -4,7 +4,23 @@ import PropTypes from 'prop-types';
 import { StyleSheet, FlatList, Text, View } from 'react-native';
 import { SwipeAction } from '../../common/components/native';
 
-class PostList extends React.PureComponent {
+export default class PostList extends React.PureComponent {
+  static defaultProps = {
+    loading: false,
+    posts: {},
+    navigation: {},
+    deletePost: () => {},
+    loadMoreRows: () => {}
+  };
+
+  static propTypes = {
+    loading: PropTypes.bool.isRequired,
+    posts: PropTypes.object,
+    navigation: PropTypes.object,
+    deletePost: PropTypes.func.isRequired,
+    loadMoreRows: PropTypes.func.isRequired
+  };
+
   onEndReachedCalledDuringMomentum = false;
 
   keyExtractor = item => item.node.id;
@@ -57,18 +73,8 @@ class PostList extends React.PureComponent {
   }
 }
 
-PostList.propTypes = {
-  loading: PropTypes.bool.isRequired,
-  posts: PropTypes.object,
-  navigation: PropTypes.object,
-  deletePost: PropTypes.func.isRequired,
-  loadMoreRows: PropTypes.func.isRequired
-};
-
 const styles = StyleSheet.create({
   container: {
     flex: 1
   }
 });
-
-export default PostList;

--- a/src/client/modules/post/components/PostList.web.jsx
+++ b/src/client/modules/post/components/PostList.web.jsx
@@ -6,13 +6,6 @@ import { PageLayout, Table, Button } from '../../common/components/web';
 import settings from '../../../../../settings';
 
 export default class PostList extends React.PureComponent {
-  static defaultProps = {
-    loading: false,
-    posts: {},
-    deletePost: () => {},
-    loadMoreRows: () => {}
-  };
-
   static propTypes = {
     loading: PropTypes.bool.isRequired,
     posts: PropTypes.object,

--- a/src/client/modules/post/components/PostList.web.jsx
+++ b/src/client/modules/post/components/PostList.web.jsx
@@ -5,7 +5,21 @@ import { Link } from 'react-router-dom';
 import { PageLayout, Table, Button } from '../../common/components/web';
 import settings from '../../../../../settings';
 
-class PostList extends React.PureComponent {
+export default class PostList extends React.PureComponent {
+  static defaultProps = {
+    loading: false,
+    posts: {},
+    deletePost: () => {},
+    loadMoreRows: () => {}
+  };
+
+  static propTypes = {
+    loading: PropTypes.bool.isRequired,
+    posts: PropTypes.object,
+    deletePost: PropTypes.func.isRequired,
+    loadMoreRows: PropTypes.func.isRequired
+  };
+
   hendleDeletePost = id => {
     const { deletePost } = this.props;
     deletePost(id);
@@ -90,12 +104,3 @@ class PostList extends React.PureComponent {
     }
   }
 }
-
-PostList.propTypes = {
-  loading: PropTypes.bool.isRequired,
-  posts: PropTypes.object,
-  deletePost: PropTypes.func.isRequired,
-  loadMoreRows: PropTypes.func.isRequired
-};
-
-export default PostList;

--- a/src/client/modules/post/containers/Post.jsx
+++ b/src/client/modules/post/containers/Post.jsx
@@ -78,6 +78,13 @@ class Post extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    if (this.subscription) {
+      // unsubscribe
+      this.subscription();
+    }
+  }
+
   subscribeToPostList = endCursor => {
     const { subscribeToMore } = this.props;
 
@@ -97,13 +104,6 @@ class Post extends React.Component {
       }
     });
   };
-
-  componentWillUnmount() {
-    if (this.subscription) {
-      // unsubscribe
-      this.subscription();
-    }
-  }
 
   render() {
     return <PostList {...this.props} />;

--- a/src/client/modules/post/containers/Post.jsx
+++ b/src/client/modules/post/containers/Post.jsx
@@ -54,9 +54,14 @@ function DeletePost(prev, id) {
 }
 
 class Post extends React.Component {
+  static propTypes = {
+    loading: PropTypes.bool.isRequired,
+    posts: PropTypes.object,
+    subscribeToMore: PropTypes.func.isRequired
+  };
+
   constructor(props) {
     super(props);
-
     this.subscription = null;
   }
 
@@ -109,12 +114,6 @@ class Post extends React.Component {
     return <PostList {...this.props} />;
   }
 }
-
-Post.propTypes = {
-  loading: PropTypes.bool.isRequired,
-  posts: PropTypes.object,
-  subscribeToMore: PropTypes.func.isRequired
-};
 
 export default compose(
   graphql(POSTS_QUERY, {

--- a/src/client/modules/post/containers/PostComments.jsx
+++ b/src/client/modules/post/containers/PostComments.jsx
@@ -62,6 +62,15 @@ class PostComments extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    this.props.onCommentSelect({ id: null, content: '' });
+
+    if (this.subscription) {
+      // unsubscribe
+      this.subscription();
+    }
+  }
+
   subscribeToCommentList = postId => {
     const { subscribeToMore } = this.props;
 
@@ -81,15 +90,6 @@ class PostComments extends React.Component {
       }
     });
   };
-
-  componentWillUnmount() {
-    this.props.onCommentSelect({ id: null, content: '' });
-
-    if (this.subscription) {
-      // unsubscribe
-      this.subscription();
-    }
-  }
 
   render() {
     return <PostCommentsView {...this.props} />;

--- a/src/client/modules/post/containers/PostComments.jsx
+++ b/src/client/modules/post/containers/PostComments.jsx
@@ -45,6 +45,14 @@ function DeleteComment(prev, id) {
 }
 
 class PostComments extends React.Component {
+  static propTypes = {
+    postId: PropTypes.number.isRequired,
+    comments: PropTypes.array.isRequired,
+    comment: PropTypes.object.isRequired,
+    onCommentSelect: PropTypes.func.isRequired,
+    subscribeToMore: PropTypes.func.isRequired
+  };
+
   constructor(props) {
     super(props);
     this.subscription = null;
@@ -95,14 +103,6 @@ class PostComments extends React.Component {
     return <PostCommentsView {...this.props} />;
   }
 }
-
-PostComments.propTypes = {
-  postId: PropTypes.number.isRequired,
-  comments: PropTypes.array.isRequired,
-  comment: PropTypes.object.isRequired,
-  onCommentSelect: PropTypes.func.isRequired,
-  subscribeToMore: PropTypes.func.isRequired
-};
 
 const PostCommentsWithApollo = compose(
   graphql(ADD_COMMENT, {

--- a/src/client/modules/post/containers/PostEdit.jsx
+++ b/src/client/modules/post/containers/PostEdit.jsx
@@ -32,6 +32,13 @@ class PostEdit extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    if (this.subscription) {
+      // unsubscribe
+      this.subscription();
+    }
+  }
+
   subscribeToPostEdit = postId => {
     const { subscribeToMore } = this.props;
 
@@ -40,13 +47,6 @@ class PostEdit extends React.Component {
       variables: { id: postId }
     });
   };
-
-  componentWillUnmount() {
-    if (this.subscription) {
-      // unsubscribe
-      this.subscription();
-    }
-  }
 
   render() {
     return <PostEditView {...this.props} />;

--- a/src/client/modules/post/containers/PostEdit.jsx
+++ b/src/client/modules/post/containers/PostEdit.jsx
@@ -11,9 +11,14 @@ import EDIT_POST from '../graphql/EditPost.graphql';
 import POST_SUBSCRIPTION from '../graphql/PostSubscription.graphql';
 
 class PostEdit extends React.Component {
+  static propTypes = {
+    loading: PropTypes.bool.isRequired,
+    post: PropTypes.object,
+    subscribeToMore: PropTypes.func.isRequired
+  };
+
   constructor(props) {
     super(props);
-
     this.subscription = null;
   }
 
@@ -52,12 +57,6 @@ class PostEdit extends React.Component {
     return <PostEditView {...this.props} />;
   }
 }
-
-PostEdit.propTypes = {
-  loading: PropTypes.bool.isRequired,
-  post: PropTypes.object,
-  subscribeToMore: PropTypes.func.isRequired
-};
 
 export default compose(
   graphql(POST_QUERY, {

--- a/src/client/modules/subscription/components/CancelSubscriptionView.web.jsx
+++ b/src/client/modules/subscription/components/CancelSubscriptionView.web.jsx
@@ -3,12 +3,6 @@ import PropTypes from 'prop-types';
 import { Button, Alert, CardGroup, CardTitle, CardText } from '../../common/components/web';
 
 export default class CancelSubscriptionView extends React.Component {
-  static defaultProps = {
-    loading: false,
-    active: false,
-    cancel: () => {}
-  };
-
   static propTypes = {
     loading: PropTypes.bool,
     active: PropTypes.bool,

--- a/src/client/modules/subscription/components/CancelSubscriptionView.web.jsx
+++ b/src/client/modules/subscription/components/CancelSubscriptionView.web.jsx
@@ -2,7 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Alert, CardGroup, CardTitle, CardText } from '../../common/components/web';
 
-class CancelSubscriptionView extends React.Component {
+export default class CancelSubscriptionView extends React.Component {
+  static defaultProps = {
+    loading: false,
+    active: false,
+    cancel: () => {}
+  };
+
+  static propTypes = {
+    loading: PropTypes.bool,
+    active: PropTypes.bool,
+    cancel: PropTypes.func.isRequired
+  };
+
   state = {
     cancelling: false,
     errors: null
@@ -41,11 +53,3 @@ class CancelSubscriptionView extends React.Component {
     );
   }
 }
-
-CancelSubscriptionView.propTypes = {
-  cancel: PropTypes.func.isRequired,
-  loading: PropTypes.bool,
-  active: PropTypes.bool
-};
-
-export default CancelSubscriptionView;

--- a/src/client/modules/subscription/components/SubscriptionCardForm.web.jsx
+++ b/src/client/modules/subscription/components/SubscriptionCardForm.web.jsx
@@ -8,6 +8,22 @@ import { Form, RenderField, Button, Alert } from '../../common/components/web';
 const required = value => (value ? undefined : 'Required');
 
 class SubscriptionCardForm extends React.Component {
+  static defaultProps = {
+    submitting: false,
+    action: '',
+    error: '',
+    handleSubmit: () => {},
+    onSubmit: () => {}
+  };
+
+  static propTypes = {
+    submitting: PropTypes.bool,
+    action: PropTypes.string.isRequired,
+    error: PropTypes.string,
+    handleSubmit: PropTypes.func,
+    onSubmit: PropTypes.func
+  };
+
   onSubmit = async ({ name }) => {
     const { stripe } = this.props;
     const { token, error } = await stripe.createToken({ name });
@@ -43,14 +59,6 @@ class SubscriptionCardForm extends React.Component {
     );
   }
 }
-
-SubscriptionCardForm.propTypes = {
-  handleSubmit: PropTypes.func,
-  onSubmit: PropTypes.func,
-  submitting: PropTypes.bool,
-  action: PropTypes.string.isRequired,
-  error: PropTypes.string
-};
 
 export default injectStripe(
   reduxForm({

--- a/src/client/modules/subscription/components/SubscriptionCardForm.web.jsx
+++ b/src/client/modules/subscription/components/SubscriptionCardForm.web.jsx
@@ -8,14 +8,6 @@ import { Form, RenderField, Button, Alert } from '../../common/components/web';
 const required = value => (value ? undefined : 'Required');
 
 class SubscriptionCardForm extends React.Component {
-  static defaultProps = {
-    submitting: false,
-    action: '',
-    error: '',
-    handleSubmit: () => {},
-    onSubmit: () => {}
-  };
-
   static propTypes = {
     submitting: PropTypes.bool,
     action: PropTypes.string.isRequired,

--- a/src/client/modules/subscription/components/SubscriptionView.web.jsx
+++ b/src/client/modules/subscription/components/SubscriptionView.web.jsx
@@ -9,7 +9,15 @@ import { PageLayout } from '../../common/components/web';
 import SubscriptionCardForm from './SubscriptionCardForm';
 import settings from '../../../../../settings';
 
-class SubscriptionView extends React.Component {
+export default class SubscriptionView extends React.Component {
+  static defaultProps = {
+    subscribe: () => {}
+  };
+
+  static propTypes = {
+    subscribe: PropTypes.func.isRequired
+  };
+
   state = {
     client: !__SSR__ && !__TEST__
   };
@@ -60,9 +68,3 @@ class SubscriptionView extends React.Component {
     );
   }
 }
-
-SubscriptionView.propTypes = {
-  subscribe: PropTypes.func.isRequired
-};
-
-export default SubscriptionView;

--- a/src/client/modules/subscription/components/SubscriptionView.web.jsx
+++ b/src/client/modules/subscription/components/SubscriptionView.web.jsx
@@ -10,10 +10,6 @@ import SubscriptionCardForm from './SubscriptionCardForm';
 import settings from '../../../../../settings';
 
 export default class SubscriptionView extends React.Component {
-  static defaultProps = {
-    subscribe: () => {}
-  };
-
   static propTypes = {
     subscribe: PropTypes.func.isRequired
   };

--- a/src/client/modules/subscription/components/SubscriptionView.web.jsx
+++ b/src/client/modules/subscription/components/SubscriptionView.web.jsx
@@ -14,6 +14,10 @@ class SubscriptionView extends React.Component {
     client: !__SSR__ && !__TEST__
   };
 
+  componentDidMount() {
+    this.setState({ client: __CLIENT__ });
+  }
+
   onSubmit = subscribe => async values => {
     const result = await subscribe(values);
 
@@ -25,10 +29,6 @@ class SubscriptionView extends React.Component {
       throw new SubmissionError(submitError);
     }
   };
-
-  componentDidMount() {
-    this.setState({ client: __CLIENT__ });
-  }
 
   render() {
     const { subscribe } = this.props;

--- a/src/client/modules/subscription/components/UpdateCardView.web.jsx
+++ b/src/client/modules/subscription/components/UpdateCardView.web.jsx
@@ -9,7 +9,15 @@ import { PageLayout } from '../../common/components/web';
 import SubscriptionCardForm from './SubscriptionCardForm';
 import settings from '../../../../../settings';
 
-class UpdateCardView extends React.Component {
+export default class UpdateCardView extends React.Component {
+  static defaultProps = {
+    updateCard: () => {}
+  };
+
+  static propTypes = {
+    updateCard: PropTypes.func.isRequired
+  };
+
   onSubmit = updateCard => async values => {
     const result = await updateCard(values);
 
@@ -50,9 +58,3 @@ class UpdateCardView extends React.Component {
     );
   }
 }
-
-UpdateCardView.propTypes = {
-  updateCard: PropTypes.func.isRequired
-};
-
-export default UpdateCardView;

--- a/src/client/modules/subscription/components/UpdateCardView.web.jsx
+++ b/src/client/modules/subscription/components/UpdateCardView.web.jsx
@@ -10,10 +10,6 @@ import SubscriptionCardForm from './SubscriptionCardForm';
 import settings from '../../../../../settings';
 
 export default class UpdateCardView extends React.Component {
-  static defaultProps = {
-    updateCard: () => {}
-  };
-
   static propTypes = {
     updateCard: PropTypes.func.isRequired
   };

--- a/src/client/modules/subscription/containers/Subscription.js
+++ b/src/client/modules/subscription/containers/Subscription.js
@@ -13,6 +13,14 @@ import settings from '../../../../../settings';
 
 // react-stripe-elements will not render on the server.
 class Subscription extends React.Component {
+  static defaultProps = {
+    subscribe: () => {}
+  };
+
+  static propTypes = {
+    subscribe: PropTypes.func.isRequired
+  };
+
   render() {
     return (
       <div>
@@ -27,10 +35,6 @@ class Subscription extends React.Component {
     );
   }
 }
-
-Subscription.propTypes = {
-  subscribe: PropTypes.func.isRequired
-};
 
 const SubscriptionViewWithApollo = compose(
   graphql(SUBSCRIBE, {

--- a/src/client/modules/subscription/containers/Subscription.js
+++ b/src/client/modules/subscription/containers/Subscription.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { graphql, compose } from 'react-apollo';
 import { StripeProvider } from 'react-stripe-elements';
 
@@ -13,14 +12,6 @@ import settings from '../../../../../settings';
 
 // react-stripe-elements will not render on the server.
 class Subscription extends React.Component {
-  static defaultProps = {
-    subscribe: () => {}
-  };
-
-  static propTypes = {
-    subscribe: PropTypes.func.isRequired
-  };
-
   render() {
     return (
       <div>

--- a/src/client/modules/subscription/containers/UpdateCard.js
+++ b/src/client/modules/subscription/containers/UpdateCard.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { graphql, compose } from 'react-apollo';
 import { StripeProvider } from 'react-stripe-elements';
 
@@ -12,14 +11,6 @@ import settings from '../../../../../settings';
 
 // react-stripe-elements will not render on the server.
 class UpdateCard extends React.Component {
-  static defaultProps = {
-    updateCard: () => {}
-  };
-
-  static propTypes = {
-    updateCard: PropTypes.func.isRequired
-  };
-
   render() {
     return (
       <div>

--- a/src/client/modules/subscription/containers/UpdateCard.js
+++ b/src/client/modules/subscription/containers/UpdateCard.js
@@ -12,6 +12,14 @@ import settings from '../../../../../settings';
 
 // react-stripe-elements will not render on the server.
 class UpdateCard extends React.Component {
+  static defaultProps = {
+    updateCard: () => {}
+  };
+
+  static propTypes = {
+    updateCard: PropTypes.func.isRequired
+  };
+
   render() {
     return (
       <div>
@@ -26,10 +34,6 @@ class UpdateCard extends React.Component {
     );
   }
 }
-
-UpdateCard.propTypes = {
-  updateCard: PropTypes.func.isRequired
-};
 
 const UpdateCardWithApollo = compose(
   graphql(UPDATE_CARD, {

--- a/src/client/modules/upload/components/UploadView.web.jsx
+++ b/src/client/modules/upload/components/UploadView.web.jsx
@@ -6,7 +6,19 @@ import filesize from 'filesize';
 import { PageLayout, Row, Col, Table, Button, Alert } from '../../common/components/web';
 import settings from '../../../../../settings';
 
-class UploadView extends React.PureComponent {
+export default class UploadView extends React.PureComponent {
+  static defaultProps = {
+    files: [],
+    uploadFiles: () => {},
+    removeFile: () => {}
+  };
+
+  static propTypes = {
+    files: PropTypes.array,
+    uploadFiles: PropTypes.func.isRequired,
+    removeFile: PropTypes.func.isRequired
+  };
+
   state = {
     error: null
   };
@@ -89,11 +101,3 @@ class UploadView extends React.PureComponent {
     );
   }
 }
-
-UploadView.propTypes = {
-  files: PropTypes.array,
-  uploadFiles: PropTypes.func.isRequired,
-  removeFile: PropTypes.func.isRequired
-};
-
-export default UploadView;

--- a/src/client/modules/upload/components/UploadView.web.jsx
+++ b/src/client/modules/upload/components/UploadView.web.jsx
@@ -7,12 +7,6 @@ import { PageLayout, Row, Col, Table, Button, Alert } from '../../common/compone
 import settings from '../../../../../settings';
 
 export default class UploadView extends React.PureComponent {
-  static defaultProps = {
-    files: [],
-    uploadFiles: () => {},
-    removeFile: () => {}
-  };
-
   static propTypes = {
     files: PropTypes.array,
     uploadFiles: PropTypes.func.isRequired,

--- a/src/client/modules/user/components/ForgotPasswordView.web.jsx
+++ b/src/client/modules/user/components/ForgotPasswordView.web.jsx
@@ -8,7 +8,17 @@ import { PageLayout } from '../../common/components/web';
 import ForgotPasswordForm from '../components/ForgotPasswordForm';
 import settings from '../../../../../settings';
 
-class ForgotPasswordView extends React.Component {
+export default class ForgotPasswordView extends React.Component {
+  static defaultProps = {
+    forgotPassword: () => {},
+    onFormSubmitted: () => {}
+  };
+
+  static propTypes = {
+    forgotPassword: PropTypes.func.isRequired,
+    onFormSubmitted: PropTypes.func.isRequired
+  };
+
   state = {
     sent: false
   };
@@ -54,10 +64,3 @@ class ForgotPasswordView extends React.Component {
     );
   }
 }
-
-ForgotPasswordView.propTypes = {
-  forgotPassword: PropTypes.func.isRequired,
-  onFormSubmitted: PropTypes.func.isRequired
-};
-
-export default ForgotPasswordView;

--- a/src/client/modules/user/components/ForgotPasswordView.web.jsx
+++ b/src/client/modules/user/components/ForgotPasswordView.web.jsx
@@ -9,11 +9,6 @@ import ForgotPasswordForm from '../components/ForgotPasswordForm';
 import settings from '../../../../../settings';
 
 export default class ForgotPasswordView extends React.Component {
-  static defaultProps = {
-    forgotPassword: () => {},
-    onFormSubmitted: () => {}
-  };
-
   static propTypes = {
     forgotPassword: PropTypes.func.isRequired,
     onFormSubmitted: PropTypes.func.isRequired

--- a/src/client/modules/user/components/LoginView.web.jsx
+++ b/src/client/modules/user/components/LoginView.web.jsx
@@ -8,7 +8,17 @@ import { PageLayout, Card, CardGroup, CardTitle, CardText } from '../../common/c
 import LoginForm from '../components/LoginForm';
 import settings from '../../../../../settings';
 
-class LoginView extends React.PureComponent {
+export default class LoginView extends React.PureComponent {
+  static defaultProps = {
+    error: '',
+    login: () => {}
+  };
+
+  static propTypes = {
+    error: PropTypes.string,
+    login: PropTypes.func.isRequired
+  };
+
   onSubmit = login => async values => {
     const result = await login(values);
 
@@ -56,10 +66,3 @@ class LoginView extends React.PureComponent {
     );
   }
 }
-
-LoginView.propTypes = {
-  login: PropTypes.func.isRequired,
-  error: PropTypes.string
-};
-
-export default LoginView;

--- a/src/client/modules/user/components/LoginView.web.jsx
+++ b/src/client/modules/user/components/LoginView.web.jsx
@@ -9,11 +9,6 @@ import LoginForm from '../components/LoginForm';
 import settings from '../../../../../settings';
 
 export default class LoginView extends React.PureComponent {
-  static defaultProps = {
-    error: '',
-    login: () => {}
-  };
-
   static propTypes = {
     error: PropTypes.string,
     login: PropTypes.func.isRequired

--- a/src/client/modules/user/components/ProfileView.jsx
+++ b/src/client/modules/user/components/ProfileView.jsx
@@ -1,6 +1,5 @@
 /*eslint-disable no-unused-vars*/
 import React from 'react';
-import PropTypes from 'prop-types';
 import { StyleSheet, Text, View } from 'react-native';
 
 const ProfileView = () => {
@@ -29,7 +28,5 @@ const styles = StyleSheet.create({
     marginRight: 15
   }
 });
-
-ProfileView.propTypes = {};
 
 export default ProfileView;

--- a/src/client/modules/user/components/RegisterView.web.jsx
+++ b/src/client/modules/user/components/RegisterView.web.jsx
@@ -8,7 +8,15 @@ import { PageLayout } from '../../common/components/web';
 import RegisterForm from '../components/RegisterForm';
 import settings from '../../../../../settings';
 
-class RegisterView extends React.PureComponent {
+export default class RegisterView extends React.PureComponent {
+  static defaultProps = {
+    register: () => {}
+  };
+
+  static propTypes = {
+    register: PropTypes.func.isRequired
+  };
+
   onSubmit = async values => {
     const { register } = this.props;
     const result = await register(values);
@@ -46,9 +54,3 @@ class RegisterView extends React.PureComponent {
     );
   }
 }
-
-RegisterView.propTypes = {
-  register: PropTypes.func.isRequired
-};
-
-export default RegisterView;

--- a/src/client/modules/user/components/RegisterView.web.jsx
+++ b/src/client/modules/user/components/RegisterView.web.jsx
@@ -9,10 +9,6 @@ import RegisterForm from '../components/RegisterForm';
 import settings from '../../../../../settings';
 
 export default class RegisterView extends React.PureComponent {
-  static defaultProps = {
-    register: () => {}
-  };
-
   static propTypes = {
     register: PropTypes.func.isRequired
   };

--- a/src/client/modules/user/components/ResetPasswordView.web.jsx
+++ b/src/client/modules/user/components/ResetPasswordView.web.jsx
@@ -8,10 +8,6 @@ import ResetPasswordForm from '../components/ResetPasswordForm';
 import settings from '../../../../../settings';
 
 export default class ResetPasswordView extends React.Component {
-  static defaultProps = {
-    resetPassword: () => {}
-  };
-
   static propTypes = {
     resetPassword: PropTypes.func.isRequired,
     match: PropTypes.shape({

--- a/src/client/modules/user/components/ResetPasswordView.web.jsx
+++ b/src/client/modules/user/components/ResetPasswordView.web.jsx
@@ -7,7 +7,20 @@ import { PageLayout } from '../../common/components/web';
 import ResetPasswordForm from '../components/ResetPasswordForm';
 import settings from '../../../../../settings';
 
-class ResetPasswordView extends React.Component {
+export default class ResetPasswordView extends React.Component {
+  static defaultProps = {
+    resetPassword: () => {}
+  };
+
+  static propTypes = {
+    resetPassword: PropTypes.func.isRequired,
+    match: PropTypes.shape({
+      params: PropTypes.shape({
+        token: PropTypes.string.isRequired
+      }).isRequired
+    }).isRequired
+  };
+
   onSubmit = resetPassword => async values => {
     const result = await resetPassword({
       ...values,
@@ -47,14 +60,3 @@ class ResetPasswordView extends React.Component {
     );
   }
 }
-
-ResetPasswordView.propTypes = {
-  resetPassword: PropTypes.func.isRequired,
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      token: PropTypes.string.isRequired
-    }).isRequired
-  }).isRequired
-};
-
-export default ResetPasswordView;

--- a/src/client/modules/user/components/UserEditView.jsx
+++ b/src/client/modules/user/components/UserEditView.jsx
@@ -10,13 +10,6 @@ import UserForm from './UserForm';
 import settings from '../../../../../settings';
 
 export default class UserEditView extends React.PureComponent {
-  static defaultProps = {
-    loading: false,
-    user: {},
-    addUser: () => {},
-    editUser: () => {}
-  };
-
   static propTypes = {
     loading: PropTypes.bool.isRequired,
     user: PropTypes.object,

--- a/src/client/modules/user/components/UserEditView.jsx
+++ b/src/client/modules/user/components/UserEditView.jsx
@@ -9,7 +9,21 @@ import { PageLayout } from '../../common/components/web';
 import UserForm from './UserForm';
 import settings from '../../../../../settings';
 
-class UserEditView extends React.PureComponent {
+export default class UserEditView extends React.PureComponent {
+  static defaultProps = {
+    loading: false,
+    user: {},
+    addUser: () => {},
+    editUser: () => {}
+  };
+
+  static propTypes = {
+    loading: PropTypes.bool.isRequired,
+    user: PropTypes.object,
+    addUser: PropTypes.func.isRequired,
+    editUser: PropTypes.func.isRequired
+  };
+
   onSubmit = async values => {
     const { user, addUser, editUser } = this.props;
     let result = null;
@@ -73,12 +87,3 @@ class UserEditView extends React.PureComponent {
     }
   }
 }
-
-UserEditView.propTypes = {
-  loading: PropTypes.bool.isRequired,
-  user: PropTypes.object,
-  addUser: PropTypes.func.isRequired,
-  editUser: PropTypes.func.isRequired
-};
-
-export default UserEditView;

--- a/src/client/modules/user/components/UserForm.web.jsx
+++ b/src/client/modules/user/components/UserForm.web.jsx
@@ -22,7 +22,7 @@ const validate = values => {
 
 const UserForm = ({ handleSubmit, submitting, onSubmit, error }) => {
   return (
-    <Form name="post" onSubmit={handleSubmit(onSubmit)}>
+    <Form name="user" onSubmit={handleSubmit(onSubmit)}>
       <Field name="username" component={RenderField} type="text" label="Username" validate={[required, minLength3]} />
       <Field name="email" component={RenderField} type="email" label="Email" validate={required} />
       <Field name="role" component={RenderSelect} type="select" label="Role">

--- a/src/client/modules/user/components/UsersFilterView.web.jsx
+++ b/src/client/modules/user/components/UsersFilterView.web.jsx
@@ -4,15 +4,6 @@ import { DebounceInput } from 'react-debounce-input';
 import { Form, FormItem, Select, Option, Label, Input } from '../../common/components/web';
 
 export default class UsersFilterView extends React.PureComponent {
-  static defaultProps = {
-    searchText: '',
-    role: '',
-    isActive: false,
-    onSearchTextChange: () => {},
-    onRoleChange: () => {},
-    onIsActiveChange: () => {}
-  };
-
   static propTypes = {
     searchText: PropTypes.string,
     role: PropTypes.string,

--- a/src/client/modules/user/components/UsersFilterView.web.jsx
+++ b/src/client/modules/user/components/UsersFilterView.web.jsx
@@ -3,7 +3,25 @@ import PropTypes from 'prop-types';
 import { DebounceInput } from 'react-debounce-input';
 import { Form, FormItem, Select, Option, Label, Input } from '../../common/components/web';
 
-class UsersFilterView extends React.PureComponent {
+export default class UsersFilterView extends React.PureComponent {
+  static defaultProps = {
+    searchText: '',
+    role: '',
+    isActive: false,
+    onSearchTextChange: () => {},
+    onRoleChange: () => {},
+    onIsActiveChange: () => {}
+  };
+
+  static propTypes = {
+    searchText: PropTypes.string,
+    role: PropTypes.string,
+    isActive: PropTypes.bool,
+    onSearchTextChange: PropTypes.func.isRequired,
+    onRoleChange: PropTypes.func.isRequired,
+    onIsActiveChange: PropTypes.func.isRequired
+  };
+
   handleSearch = e => {
     const { onSearchTextChange } = this.props;
     onSearchTextChange(e.target.value);
@@ -56,14 +74,3 @@ class UsersFilterView extends React.PureComponent {
     );
   }
 }
-
-UsersFilterView.propTypes = {
-  searchText: PropTypes.string,
-  role: PropTypes.string,
-  isActive: PropTypes.bool,
-  onSearchTextChange: PropTypes.func.isRequired,
-  onRoleChange: PropTypes.func.isRequired,
-  onIsActiveChange: PropTypes.func.isRequired
-};
-
-export default UsersFilterView;

--- a/src/client/modules/user/components/UsersListView.web.jsx
+++ b/src/client/modules/user/components/UsersListView.web.jsx
@@ -3,7 +3,23 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Table, Button } from '../../common/components/web';
 
-class UsersView extends React.PureComponent {
+export default class UsersView extends React.PureComponent {
+  static defaultProps = {
+    loading: false,
+    users: [],
+    orderBy: {},
+    onOrderBy: () => {},
+    deleteUser: () => {}
+  };
+
+  static propTypes = {
+    loading: PropTypes.bool.isRequired,
+    users: PropTypes.array,
+    orderBy: PropTypes.object,
+    onOrderBy: PropTypes.func.isRequired,
+    deleteUser: PropTypes.func.isRequired
+  };
+
   state = {
     errors: []
   };
@@ -124,13 +140,3 @@ class UsersView extends React.PureComponent {
     }
   }
 }
-
-UsersView.propTypes = {
-  loading: PropTypes.bool.isRequired,
-  users: PropTypes.array,
-  orderBy: PropTypes.object,
-  onOrderBy: PropTypes.func.isRequired,
-  deleteUser: PropTypes.func.isRequired
-};
-
-export default UsersView;

--- a/src/client/modules/user/components/UsersListView.web.jsx
+++ b/src/client/modules/user/components/UsersListView.web.jsx
@@ -4,14 +4,6 @@ import { Link } from 'react-router-dom';
 import { Table, Button } from '../../common/components/web';
 
 export default class UsersView extends React.PureComponent {
-  static defaultProps = {
-    loading: false,
-    users: [],
-    orderBy: {},
-    onOrderBy: () => {},
-    deleteUser: () => {}
-  };
-
   static propTypes = {
     loading: PropTypes.bool.isRequired,
     users: PropTypes.array,

--- a/src/mobile/App.js
+++ b/src/mobile/App.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { getOperationAST } from 'graphql';
 import { ApolloProvider } from 'react-apollo';
@@ -29,7 +29,7 @@ const store = createStore(
 
 const { protocol, pathname, port } = url.parse(__BACKEND_URL__);
 
-export default class Main extends Component {
+export default class Main extends React.Component {
   static propTypes = {
     expUri: PropTypes.string
   };


### PR DESCRIPTION
- React components refactor to utilize new styles.
- Enabled eslint `react/sort-comp` property to ensure the correct order of react functions.

Default is
```
{
  order: [
    'static-methods',
    'lifecycle',
    'everything-else',
    'render'
  ],
  groups: {
    lifecycle: [
      'displayName',
      'propTypes',
      'contextTypes',
      'childContextTypes',
      'mixins',
      'statics',
      'defaultProps',
      'constructor',
      'getDefaultProps',
      'getInitialState',
      'state',
      'getChildContext',
      'componentWillMount',
      'componentDidMount',
      'componentWillReceiveProps',
      'shouldComponentUpdate',
      'componentWillUpdate',
      'componentDidUpdate',
      'componentWillUnmount'
    ]
  }
}
```