### PR TITLE
[WIP] Distinguish between concept of Web Server and concept of GraphQL API Server

### DIFF
--- a/.eslintrc.base.json
+++ b/.eslintrc.base.json
@@ -39,6 +39,7 @@
     "__SSR__": true,
     "__PERSIST_GQL__": true,
     "__API_URL__": true,
+    "__WEBSITE_URL__": true,
     "__FRONTEND_BUILD_DIR__": true,
     "__DLL_BUILD_DIR__": true
   },

--- a/.eslintrc.base.json
+++ b/.eslintrc.base.json
@@ -38,7 +38,7 @@
     "__SERVER__": true,
     "__SSR__": true,
     "__PERSIST_GQL__": true,
-    "__BACKEND_URL__": true,
+    "__API_URL__": true,
     "__FRONTEND_BUILD_DIR__": true,
     "__DLL_BUILD_DIR__": true
   },

--- a/README.md
+++ b/README.md
@@ -190,15 +190,16 @@ If you don't need some of these platforms you can turn off building their code i
 
 | Option                         | Description                                                                   |
 | ------------------------------ | ----------------------------------------------------------------------------- |
-| buildDir                | output directory for build files                                            |
-| dllBuildDir                    | output directory for Webpack DLL files used to speed up incremental builds    |
-| webpackDevPort                 | the local port used for Webpack Dev Server process to host web frontend files |
-| \_\_API_URL__                     | URL to GraphQL backend endpoint                                               |
-| ssr                            | Use server side rendering in backend                                          |
-| webpackDll                     | Utilize Webpack DLLs to speed up incremental builds                           |
-| frontendRefreshOnBackendChange | Trigger web frontend refresh when backend code changes                        |
-| reactHotLoader                 | Utilize React Hot Loader v3                                                   |
-| persistGraphQL                 | Generate and use persistent GraphQL queries                                   |
+| buildDir                       | output directory for build files                                                |
+| dllBuildDir                    | output directory for Webpack DLL files used to speed up incremental builds |
+| webpackDevPort                 | the local port used for Webpack Dev Server process to host web frontend files  |
+| \_\_API_URL__                  | URL to GraphQL backend endpoint                                                 |
+| \_\_WEBSITE_URL__              | URL to website                                                                  |
+| ssr                            | Use server side rendering in backend                                            |
+| webpackDll                     | Utilize Webpack DLLs to speed up incremental builds                             |
+| frontendRefreshOnBackendChange | Trigger web frontend refresh when backend code changes                     |
+| reactHotLoader                 | Utilize React Hot Loader v3                                                     |
+| persistGraphQL                 | Generate and use persistent GraphQL queries                                     |
 
 There are also application config options available in `config/app.js` to aid with debugging GraphQL and SQL:
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ If you don't need some of these platforms you can turn off building their code i
 | buildDir                | output directory for build files                                            |
 | dllBuildDir                    | output directory for Webpack DLL files used to speed up incremental builds    |
 | webpackDevPort                 | the local port used for Webpack Dev Server process to host web frontend files |
-| \_\_BACKEND_URL__                     | URL to GraphQL backend endpoint                                               |
+| \_\_API_URL__                     | URL to GraphQL backend endpoint                                               |
 | ssr                            | Use server side rendering in backend                                          |
 | webpackDll                     | Utilize Webpack DLLs to speed up incremental builds                           |
 | frontendRefreshOnBackendChange | Trigger web frontend refresh when backend code changes                        |

--- a/packages/client/.spinrc.js
+++ b/packages/client/.spinrc.js
@@ -31,7 +31,7 @@ const config = {
     frontendRefreshOnBackendChange: true,
     defines: {
       __DEV__: process.env.NODE_ENV !== 'production',
-      __BACKEND_URL__: '"http://localhost:8080/graphql"'
+      __API_URL__: '"http://localhost:8080/graphql"'
     }
   }
 };
@@ -39,7 +39,7 @@ const config = {
 config.options.devProxy = config.options.ssr;
 
 if (process.env.NODE_ENV === 'production') {
-  config.options.defines.__BACKEND_URL__ = '"https://apollo-universal-starter-kit.herokuapp.com/graphql"';
+  config.options.defines.__API_URL__ = '"https://apollo-universal-starter-kit.herokuapp.com/graphql"';
   // Generating source maps for production will slowdown compilation for roughly 25%
   config.options.sourceMap = false;
 }

--- a/packages/client/.spinrc.js
+++ b/packages/client/.spinrc.js
@@ -31,7 +31,8 @@ const config = {
     frontendRefreshOnBackendChange: true,
     defines: {
       __DEV__: process.env.NODE_ENV !== 'production',
-      __API_URL__: '"http://localhost:8080/graphql"'
+      __API_URL__: '"http://localhost:8080/graphql"',
+      __WEBSITE_URL__: '"http://localhost:3000"'
     }
   }
 };
@@ -40,6 +41,7 @@ config.options.devProxy = config.options.ssr;
 
 if (process.env.NODE_ENV === 'production') {
   config.options.defines.__API_URL__ = '"https://apollo-universal-starter-kit.herokuapp.com/graphql"';
+  config.options.defines.__WEBSITE_URL__ = '"https://apollo-universal-starter-kit.herokuapp.com"';
   // Generating source maps for production will slowdown compilation for roughly 25%
   config.options.sourceMap = false;
 }

--- a/packages/client/src/app/Main.jsx
+++ b/packages/client/src/app/Main.jsx
@@ -26,9 +26,9 @@ import Routes from './Routes';
 import modules from '../modules';
 import log from '../../../common/log';
 
-const { hostname, pathname, port } = url.parse(__BACKEND_URL__);
+const { hostname, pathname, port } = url.parse(__API_URL__);
 
-const uri = hostname === 'localhost' && __SSR__ ? '/graphql' : __BACKEND_URL__;
+const uri = hostname === 'localhost' && __SSR__ ? '/graphql' : __API_URL__;
 const fetch = createApolloFetch({
   uri,
   constructOptions: modules.constructFetchOptions
@@ -70,7 +70,7 @@ for (const connectionParam of modules.connectionParams) {
 
 const wsUri = (hostname === 'localhost'
   ? `${window.location.protocol}${window.location.hostname}:${__DEV__ ? port : window.location.port}${pathname}`
-  : __BACKEND_URL__
+  : __API_URL__
 ).replace(/^http/, 'ws');
 
 const wsClient = new SubscriptionClient(wsUri, {

--- a/packages/client/src/app/Main.jsx
+++ b/packages/client/src/app/Main.jsx
@@ -16,7 +16,6 @@ import { SubscriptionClient } from 'subscriptions-transport-ws';
 // eslint-disable-next-line import/no-unresolved, import/no-extraneous-dependencies, import/extensions
 // import queryMap from 'persisted_queries.json';
 import ReactGA from 'react-ga';
-import url from 'url';
 
 import RedBox from './RedBox';
 import createApolloClient from '../../../common/createApolloClient';
@@ -26,15 +25,12 @@ import Routes from './Routes';
 import modules from '../modules';
 import log from '../../../common/log';
 
-const { hostname, pathname, port } = url.parse(__API_URL__);
-
-const uri = hostname === 'localhost' && __SSR__ ? '/graphql' : __API_URL__;
 const fetch = createApolloFetch({
-  uri,
+  uri: __API_URL__,
   constructOptions: modules.constructFetchOptions
 });
 
-log.info(`Connecting to GraphQL backend at: ${uri}`);
+log.info(`Connecting to GraphQL backend at: ${__API_URL__}`);
 
 const cache = new InMemoryCache();
 
@@ -68,10 +64,7 @@ for (const connectionParam of modules.connectionParams) {
   Object.assign(connectionParams, connectionParam());
 }
 
-const wsUri = (hostname === 'localhost'
-  ? `${window.location.protocol}${window.location.hostname}:${__DEV__ ? port : window.location.port}${pathname}`
-  : __API_URL__
-).replace(/^http/, 'ws');
+const wsUri = __API_URL__.replace(/^http/, 'ws');
 
 const wsClient = new SubscriptionClient(wsUri, {
   reconnect: true,

--- a/packages/client/src/modules/user/components/LoginForm.web.jsx
+++ b/packages/client/src/modules/user/components/LoginForm.web.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withFormik } from 'formik';
-import url from 'url';
 import { NavLink, Link } from 'react-router-dom';
 import Field from '../../../utils/FieldAdapter';
 import { Form, RenderField, Alert, Button } from '../../common/components/web';
@@ -9,18 +8,12 @@ import { required, email, minLength, validateForm } from '../../../../../common/
 
 import settings from '../../../../../../settings';
 
-const { protocol, hostname, port } = url.parse(__API_URL__);
-let serverPort = process.env.PORT || port;
-if (__DEV__) {
-  serverPort = '3000';
-}
-
 const facebookLogin = () => {
-  window.location = `${protocol}//${hostname}:${serverPort}/auth/facebook`;
+  window.location = `${__WEBSITE_URL__}/auth/facebook`;
 };
 
 const googleLogin = () => {
-  window.location = `${protocol}//${hostname}:${serverPort}/auth/google`;
+  window.location = `${__WEBSITE_URL__}/auth/google`;
 };
 
 const contactFormSchema = {

--- a/packages/client/src/modules/user/components/LoginForm.web.jsx
+++ b/packages/client/src/modules/user/components/LoginForm.web.jsx
@@ -9,7 +9,7 @@ import { required, email, minLength, validateForm } from '../../../../../common/
 
 import settings from '../../../../../../settings';
 
-const { protocol, hostname, port } = url.parse(__BACKEND_URL__);
+const { protocol, hostname, port } = url.parse(__API_URL__);
 let serverPort = process.env.PORT || port;
 if (__DEV__) {
   serverPort = '3000';

--- a/packages/client/src/testHelpers/Renderer.js
+++ b/packages/client/src/testHelpers/Renderer.js
@@ -146,7 +146,7 @@ export default class Renderer {
 
     const cache = new InMemoryCache();
     let link = new MockLink(schema);
-    const isLocalhost = /localhost/.test(__BACKEND_URL__);
+    const isLocalhost = /localhost/.test(__API_URL__);
     let linkSchema = isLocalhost ? new SchemaLink({ schema: { ...serverModules.schemas } }) : {};
 
     const linkState = withClientState({ ...clientModules.resolvers, cache });

--- a/packages/client/typings/typings.d.ts
+++ b/packages/client/typings/typings.d.ts
@@ -5,6 +5,7 @@ declare var __CLIENT__: boolean;
 declare var __SSR__: boolean;
 declare var __PERSIST_GQL__: boolean;
 declare var __API_URL__: string;
+declare var __WEBSITE_URL__: string;
 
 declare module 'react-native-web' {
   const val: any;

--- a/packages/client/typings/typings.d.ts
+++ b/packages/client/typings/typings.d.ts
@@ -4,7 +4,7 @@ declare var __SERVER__: boolean;
 declare var __CLIENT__: boolean;
 declare var __SSR__: boolean;
 declare var __PERSIST_GQL__: boolean;
-declare var __BACKEND_URL__: string;
+declare var __API_URL__: string;
 
 declare module 'react-native-web' {
   const val: any;

--- a/packages/mobile/.spinrc.js
+++ b/packages/mobile/.spinrc.js
@@ -38,7 +38,8 @@ const config = {
     persistGraphQL: false,
     defines: {
       __DEV__: process.env.NODE_ENV !== 'production',
-      __API_URL__: '"http://localhost:8080/graphql"'
+      __API_URL__: '"http://localhost:8080/graphql"',
+      __WEBSITE_URL__: '"http://localhost:3000"'
     }
   }
 };
@@ -47,6 +48,7 @@ if (process.env.NODE_ENV === 'production') {
   config.builders.android.enabled = true;
   config.builders.ios.enabled = true;
   config.options.defines.__API_URL__ = '"https://apollo-universal-starter-kit.herokuapp.com/graphql"';
+  config.options.defines.__WEBSITE_URL__ = '"https://apollo-universal-starter-kit.herokuapp.com"';
   // Generating source maps for production will slowdown compilation for roughly 25%
   config.options.sourceMap = false;
 }

--- a/packages/mobile/.spinrc.js
+++ b/packages/mobile/.spinrc.js
@@ -38,7 +38,7 @@ const config = {
     persistGraphQL: false,
     defines: {
       __DEV__: process.env.NODE_ENV !== 'production',
-      __BACKEND_URL__: '"http://localhost:8080/graphql"'
+      __API_URL__: '"http://localhost:8080/graphql"'
     }
   }
 };
@@ -46,7 +46,7 @@ const config = {
 if (process.env.NODE_ENV === 'production') {
   config.builders.android.enabled = true;
   config.builders.ios.enabled = true;
-  config.options.defines.__BACKEND_URL__ = '"https://apollo-universal-starter-kit.herokuapp.com/graphql"';
+  config.options.defines.__API_URL__ = '"https://apollo-universal-starter-kit.herokuapp.com/graphql"';
   // Generating source maps for production will slowdown compilation for roughly 25%
   config.options.sourceMap = false;
 }

--- a/packages/mobile/src/App.js
+++ b/packages/mobile/src/App.js
@@ -26,7 +26,7 @@ const store = createStore(
   {} // initial state
 );
 
-const { protocol, pathname, port } = url.parse(__BACKEND_URL__);
+const { protocol, pathname, port } = url.parse(__API_URL__);
 
 export default class Main extends React.Component {
   static propTypes = {
@@ -34,11 +34,11 @@ export default class Main extends React.Component {
   };
 
   render() {
-    const { hostname } = url.parse(__BACKEND_URL__);
+    const { hostname } = url.parse(__API_URL__);
     const uri =
       this.props.expUri && hostname === 'localhost'
         ? `${protocol}//${url.parse(this.props.expUri).hostname}:${port}${pathname}`
-        : __BACKEND_URL__;
+        : __API_URL__;
     log.info(`Connecting to GraphQL backend at: ${uri}`);
     const fetch = createApolloFetch({ uri });
     const cache = new InMemoryCache();

--- a/packages/mobile/typings/typings.d.ts
+++ b/packages/mobile/typings/typings.d.ts
@@ -1,1 +1,4 @@
+declare var __API_URL__: string;
+declare var __WEBSITE_URL__: string;
+
 declare var ErrorUtils: any;

--- a/packages/server/.eslintrc
+++ b/packages/server/.eslintrc
@@ -6,5 +6,8 @@
         "config": "webpack.config.lint.js"
       }
     }
+  },
+  "globals": {
+    "__SERVER_PORT__": true
   }
 }

--- a/packages/server/.spinrc.js
+++ b/packages/server/.spinrc.js
@@ -6,7 +6,7 @@ const config = {
       entry: './src/index.ts',
       stack: ['react-native-web', 'server'],
       defines: {
-        __BACKEND_URL__: '"http://localhost:8080/graphql"',
+        __API_URL__: '"http://localhost:8080/graphql"',
         __SERVER__: true
       },
       enabled: true
@@ -29,7 +29,7 @@ const config = {
     frontendRefreshOnBackendChange: true,
     defines: {
       __DEV__: process.env.NODE_ENV !== 'production',
-      __BACKEND_URL__: '"http://localhost:8080/graphql"'
+      __API_URL__: '"http://localhost:8080/graphql"'
     }
   }
 };

--- a/packages/server/.spinrc.js
+++ b/packages/server/.spinrc.js
@@ -6,7 +6,6 @@ const config = {
       entry: './src/index.ts',
       stack: ['react-native-web', 'server'],
       defines: {
-        __API_URL__: '"http://localhost:8080/graphql"',
         __SERVER__: true
       },
       enabled: true
@@ -29,7 +28,9 @@ const config = {
     frontendRefreshOnBackendChange: true,
     defines: {
       __DEV__: process.env.NODE_ENV !== 'production',
-      __API_URL__: '"http://localhost:8080/graphql"'
+      __SERVER_PORT__: 8080,
+      __API_URL__: '"/graphql"', // Use full URL if API is external, e.g. https://example.com/graphql
+      __WEBSITE_URL__: '"http://localhost:3000"'
     }
   }
 };
@@ -37,6 +38,7 @@ const config = {
 config.options.devProxy = config.options.ssr;
 
 if (process.env.NODE_ENV === 'production') {
+  config.options.defines.__WEBSITE_URL__ = '"https://apollo-universal-starter-kit.herokuapp.com"';
   // Generating source maps for production will slowdown compilation for roughly 25%
   config.options.sourceMap = false;
 }

--- a/packages/server/src/app.js
+++ b/packages/server/src/app.js
@@ -22,7 +22,7 @@ for (const applyBeforeware of modules.beforewares) {
 
 app.use(cookiesMiddleware());
 
-const { pathname } = url.parse(__BACKEND_URL__);
+const { pathname } = url.parse(__API_URL__);
 
 // Don't rate limit heroku
 app.enable('trust proxy');

--- a/packages/server/src/app.js
+++ b/packages/server/src/app.js
@@ -3,12 +3,12 @@ import cors from 'cors';
 import bodyParser from 'body-parser';
 import path from 'path';
 import { invert, isArray } from 'lodash';
-import url from 'url';
 import cookiesMiddleware from 'universal-cookie-express';
 // eslint-disable-next-line import/no-unresolved, import/no-extraneous-dependencies, import/extensions
 import queryMap from 'persisted_queries.json';
-import modules from './modules';
 
+import { isApiExternal } from './net';
+import modules from './modules';
 import websiteMiddleware from './middleware/website';
 import graphiqlMiddleware from './middleware/graphiql';
 import graphqlMiddleware from './middleware/graphql';
@@ -21,8 +21,6 @@ for (const applyBeforeware of modules.beforewares) {
 }
 
 app.use(cookiesMiddleware());
-
-const { pathname } = url.parse(__API_URL__);
 
 // Don't rate limit heroku
 app.enable('trust proxy');
@@ -46,10 +44,10 @@ if (__DEV__) {
   app.use('/', express.static(__DLL_BUILD_DIR__, { maxAge: '180 days' }));
 }
 
-if (__PERSIST_GQL__) {
+if (__PERSIST_GQL__ && !isApiExternal) {
   const invertedMap = invert(queryMap);
 
-  app.use(pathname, (req, resp, next) => {
+  app.use(__API_URL__, (req, resp, next) => {
     if (isArray(req.body)) {
       req.body = req.body.map(body => {
         return {
@@ -77,7 +75,9 @@ if (__DEV__) {
     res.send(process.cwd() + path.sep);
   });
 }
-app.use(pathname, (...args) => graphqlMiddleware(...args));
+if (!isApiExternal) {
+  app.use(__API_URL__, (...args) => graphqlMiddleware(...args));
+}
 app.use('/graphiql', (...args) => graphiqlMiddleware(...args));
 app.use((...args) => websiteMiddleware(queryMap)(...args));
 if (__DEV__) {

--- a/packages/server/src/middleware/error.js
+++ b/packages/server/src/middleware/error.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
-import url from 'url';
+
+import { isApiExternal } from '../net';
 import log from '../../../common/log';
 
 let assetMap;
@@ -19,15 +20,13 @@ const stripCircular = (from, seen) => {
   return to;
 };
 
-const { pathname } = url.parse(__API_URL__);
-
 /*
  * The code below MUST be declared as a function, not closure,
  * otherwise Express will fail to execute this handler
  */
 // eslint-disable-next-line no-unused-vars
 function errorMiddleware(e, req, res, next) {
-  if (req.path === pathname) {
+  if (!isApiExternal && req.path === __API_URL__) {
     const stack = e.stack.toString().replace(/[\n]/g, '\\n');
     res.status(200).send(`[{"data": {}, "errors":[{"message": "${stack}"}]}]`);
   } else {

--- a/packages/server/src/middleware/error.js
+++ b/packages/server/src/middleware/error.js
@@ -19,7 +19,7 @@ const stripCircular = (from, seen) => {
   return to;
 };
 
-const { pathname } = url.parse(__BACKEND_URL__);
+const { pathname } = url.parse(__API_URL__);
 
 /*
  * The code below MUST be declared as a function, not closure,

--- a/packages/server/src/middleware/graphiql.js
+++ b/packages/server/src/middleware/graphiql.js
@@ -1,11 +1,12 @@
 import { graphiqlExpress } from 'apollo-server-express';
 import url from 'url';
 
-const { protocol, hostname, pathname, port } = url.parse(__API_URL__);
+import { isApiExternal, serverPort } from '../net';
 
 export default graphiqlExpress(req => {
-  const subscriptionsUrl = (hostname === 'localhost'
-    ? `${protocol}//${url.parse(req.get('Referer') || `${protocol}//${hostname}`).hostname}:${port}${pathname}`
+  const { protocol, hostname } = url.parse(req.get('Referer') || `http://localhost`);
+  const subscriptionsUrl = (!isApiExternal
+    ? `${protocol}//${hostname}:${serverPort}${__API_URL__}`
     : __API_URL__
   ).replace(/^http/, 'ws');
 

--- a/packages/server/src/middleware/graphiql.js
+++ b/packages/server/src/middleware/graphiql.js
@@ -1,12 +1,12 @@
 import { graphiqlExpress } from 'apollo-server-express';
 import url from 'url';
 
-const { protocol, hostname, pathname, port } = url.parse(__BACKEND_URL__);
+const { protocol, hostname, pathname, port } = url.parse(__API_URL__);
 
 export default graphiqlExpress(req => {
   const subscriptionsUrl = (hostname === 'localhost'
     ? `${protocol}//${url.parse(req.get('Referer') || `${protocol}//${hostname}`).hostname}:${port}${pathname}`
-    : __BACKEND_URL__
+    : __API_URL__
   ).replace(/^http/, 'ws');
 
   return {

--- a/packages/server/src/middleware/html.jsx
+++ b/packages/server/src/middleware/html.jsx
@@ -4,7 +4,7 @@ import serialize from 'serialize-javascript';
 import modules from '../../../client/src/modules';
 import { styles } from '../../../client/src/modules/common/components/web';
 
-const Html = ({ content, state, assetMap, css, helmet, token, refreshToken }) => {
+const Html = ({ content, state, assetMap, css, helmet }) => {
   const htmlAttrs = helmet.htmlAttributes.toComponent(); // react-helmet html document tags
   const bodyAttrs = helmet.bodyAttributes.toComponent(); // react-helmet body document tags
 
@@ -45,7 +45,7 @@ const Html = ({ content, state, assetMap, css, helmet, token, refreshToken }) =>
           dangerouslySetInnerHTML={{
             __html: `window.__APOLLO_STATE__=${serialize(state, {
               isJSON: true
-            })};window.localStorage.setItem('token','${token}');window.localStorage.setItem('refreshToken','${refreshToken}');`
+            })};`
           }}
           charSet="UTF-8"
         />
@@ -61,9 +61,7 @@ Html.propTypes = {
   state: PropTypes.object.isRequired,
   assetMap: PropTypes.object.isRequired,
   css: PropTypes.array,
-  helmet: PropTypes.object,
-  token: PropTypes.string,
-  refreshToken: PropTypes.string
+  helmet: PropTypes.object
 };
 
 export default Html;

--- a/packages/server/src/middleware/website.jsx
+++ b/packages/server/src/middleware/website.jsx
@@ -28,7 +28,7 @@ import settings from '../../../../settings';
 
 let assetMap;
 
-const { protocol, hostname, port, pathname } = url.parse(__BACKEND_URL__);
+const { protocol, hostname, port, pathname } = url.parse(__API_URL__);
 const apiUrl = `${protocol}//${hostname}:${process.env.PORT || port}${pathname}`;
 
 const renderServerSide = async (req, res) => {
@@ -46,7 +46,7 @@ const renderServerSide = async (req, res) => {
     next();
   });
   const cache = new InMemoryCache();
-  const isLocalhost = /localhost/.test(__BACKEND_URL__);
+  const isLocalhost = /localhost/.test(__API_URL__);
   let link = new BatchHttpLink({ fetch });
   const linkState = withClientState({ ...clientModules.resolvers, cache });
   let linkSchema = isLocalhost ? new SchemaLink({ schema: { ...modules.schemas } }) : {};

--- a/packages/server/src/modules/apolloEngine/index.js
+++ b/packages/server/src/modules/apolloEngine/index.js
@@ -7,7 +7,7 @@ import settings from '../../../../../settings';
 let engine;
 
 if (settings.engine.engineConfig.apiKey) {
-  const { protocol, hostname, port, pathname } = url.parse(__BACKEND_URL__);
+  const { protocol, hostname, port, pathname } = url.parse(__API_URL__);
   const apiUrl = `${protocol}//${hostname}:${process.env.PORT || port}${pathname}`;
   const serverPort = process.env.PORT || port;
 

--- a/packages/server/src/modules/apolloEngine/index.js
+++ b/packages/server/src/modules/apolloEngine/index.js
@@ -1,16 +1,13 @@
 import { Engine } from 'apollo-engine';
 import url from 'url';
 
+import { apiUrl, serverPort } from '../../net';
 import Feature from '../connector';
 import settings from '../../../../../settings';
 
 let engine;
 
 if (settings.engine.engineConfig.apiKey) {
-  const { protocol, hostname, port, pathname } = url.parse(__API_URL__);
-  const apiUrl = `${protocol}//${hostname}:${process.env.PORT || port}${pathname}`;
-  const serverPort = process.env.PORT || port;
-
   engine = new Engine({
     ...settings.engine,
     origins: [
@@ -22,7 +19,7 @@ if (settings.engine.engineConfig.apiKey) {
       }
     ],
     graphqlPort: serverPort, // GraphQL port
-    endpoint: pathname // GraphQL endpoint suffix - '/graphql' by default
+    endpoint: url.parse(__API_URL__).pathname // GraphQL endpoint suffix - '/graphql' by default
   });
 
   engine.start();

--- a/packages/server/src/modules/subscription/stripeLocal.js
+++ b/packages/server/src/modules/subscription/stripeLocal.js
@@ -15,7 +15,7 @@ export default () => {
       log('Starting stripe local proxy');
       require('stripe-local')({
         secretKey: settings.subscription.stripeSecretKey,
-        webhookUrl: 'http://localhost:3000/stripe/webhook'
+        webhookUrl: `http://localhost:3000/stripe/webhook`
       });
       running = true;
     }

--- a/packages/server/src/modules/user/auth/token.js
+++ b/packages/server/src/modules/user/auth/token.js
@@ -3,6 +3,9 @@ import settings from '../../../../../../settings';
 import { refreshTokens, tryLoginSerial } from './index';
 
 export default (SECRET, User, jwt) => async (req, res, next) => {
+  if (req.path !== __API_URL__) {
+    return next();
+  }
   try {
     let token = req.universalCookies.get('x-token') || req.headers['x-token'];
 
@@ -17,7 +20,7 @@ export default (SECRET, User, jwt) => async (req, res, next) => {
         token = undefined;
       }
     }
-    //console.log(token);
+    console.log('token mw:', req.url, token);
     if (token && token !== 'null') {
       try {
         const { user } = jwt.verify(token, SECRET);

--- a/packages/server/src/modules/user/index.js
+++ b/packages/server/src/modules/user/index.js
@@ -10,6 +10,7 @@ import createResolvers from './resolvers';
 import { refreshTokens, createTokens } from './auth';
 import tokenMiddleware from './auth/token';
 import confirmMiddleware from './confirm';
+import { isApiExternal } from '../../net';
 import Feature from '../connector';
 import scopes from './auth/scopes';
 import settings from '../../../../../settings';
@@ -183,7 +184,9 @@ export default new Feature({
     };
   },
   middleware: app => {
-    app.use(tokenMiddleware(SECRET, User, jwt));
+    if (!isApiExternal) {
+      app.use(tokenMiddleware(SECRET, User, jwt));
+    }
 
     if (settings.user.auth.password.sendConfirmationEmail) {
       app.get('/confirmation/:token', confirmMiddleware(SECRET, User, jwt));

--- a/packages/server/src/modules/user/resolvers.js
+++ b/packages/server/src/modules/user/resolvers.js
@@ -120,11 +120,7 @@ export default pubsub => ({
           // async email
           jwt.sign({ user: pick(user, 'id') }, context.SECRET, { expiresIn: '1d' }, (err, emailToken) => {
             const encodedToken = Buffer.from(emailToken).toString('base64');
-            let url;
-            if (__DEV__) {
-              url = `${context.req.protocol}://localhost:3000/confirmation/${encodedToken}`;
-            }
-            url = `${context.req.protocol}://${context.req.get('host')}/confirmation/${encodedToken}`;
+            const url = `${__WEBSITE_URL__}/confirmation/${encodedToken}`;
             context.mailer.sendMail({
               from: `${settings.app.name} <${process.env.EMAIL_USER}>`,
               to: user.email,
@@ -178,6 +174,7 @@ export default pubsub => ({
 
         context.req.universalCookies.remove('r-token');
         context.req.universalCookies.remove('r-refresh-token');
+        console.log('path:', context.req.path, context.req.universalCookies);
       }
 
       return true;
@@ -222,11 +219,7 @@ export default pubsub => ({
             // async email
             jwt.sign({ user: pick(user, 'id') }, context.SECRET, { expiresIn: '1d' }, (err, emailToken) => {
               const encodedToken = Buffer.from(emailToken).toString('base64');
-              let url;
-              if (__DEV__) {
-                url = `${context.req.protocol}://localhost:3000/confirmation/${encodedToken}`;
-              }
-              url = `${context.req.protocol}://${context.req.get('host')}/confirmation/${encodedToken}`;
+              const url = `${__WEBSITE_URL__}/confirmation/${encodedToken}`;
               context.mailer.sendMail({
                 from: `${settings.app.name} <${process.env.EMAIL_USER}>`,
                 to: user.email,
@@ -329,11 +322,7 @@ export default pubsub => ({
             (err, emailToken) => {
               // encoded token since react router does not match dots in params
               const encodedToken = Buffer.from(emailToken).toString('base64');
-              let url;
-              if (__DEV__) {
-                url = `${context.req.protocol}://localhost:3000/reset-password/${encodedToken}`;
-              }
-              url = `${context.req.protocol}://${context.req.get('host')}/reset-password/${encodedToken}`;
+              const url = `${__WEBSITE_URL__}/reset-password/${encodedToken}`;
               context.mailer.sendMail({
                 from: `${settings.app.name} <${process.env.EMAIL_USER}>`,
                 to: user.email,

--- a/packages/server/src/net.js
+++ b/packages/server/src/net.js
@@ -1,0 +1,5 @@
+import url from 'url';
+
+export const serverPort = process.env.PORT || __SERVER_PORT__;
+export const isApiExternal = !!url.parse(__API_URL__).protocol;
+export const apiUrl = !isApiExternal ? `http://localhost:${serverPort}${__API_URL__}` : __API_URL__;

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -1,15 +1,12 @@
-import url from 'url';
 import http from 'http';
 import addGraphQLSubscriptions from './api/subscriptions';
 
+import { serverPort } from './net';
 import app from './app';
 import log from '../../common/log';
 
 // eslint-disable-next-line import/no-mutable-exports
 let server;
-
-const { port } = url.parse(__API_URL__);
-const serverPort = process.env.PORT || port || 8080;
 
 server = http.createServer();
 server.on('request', app);

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -8,7 +8,7 @@ import log from '../../common/log';
 // eslint-disable-next-line import/no-mutable-exports
 let server;
 
-const { port } = url.parse(__BACKEND_URL__);
+const { port } = url.parse(__API_URL__);
 const serverPort = process.env.PORT || port || 8080;
 
 server = http.createServer();

--- a/packages/server/typings/typings.d.ts
+++ b/packages/server/typings/typings.d.ts
@@ -1,0 +1,3 @@
+declare var __SERVER_PORT__: number;
+declare var __API_URL__: string;
+


### PR DESCRIPTION
Currently all the code do not distinguish two concepts - the web server that hosts web front-end code and the GraphQL API server. This confuses people who want to have server side rendering, but still want to use external GraphQL API implementation. Another problem is because Web Server endpoint is not specified the most of the code that needs Web Server URL now hardcodes port 3000 during development and uses port from GraphQL API endpoint. 

The goal of this pull request is to separate these two concepts across all the code and remove port 3000 hardcoding.