### PR TITLE
Implement a way to redefine app router in a module

### DIFF
--- a/packages/client/src/app/Routes.jsx
+++ b/packages/client/src/app/Routes.jsx
@@ -1,9 +1,7 @@
-import { TabNavigator } from 'react-navigation';
-
 import modules from '../modules';
 
-const MainScreenNavigator = TabNavigator({
-  ...modules.tabItems
-});
+if (!modules.router) {
+  throw new Error('At least one router must be defined in modules');
+}
 
-export default MainScreenNavigator;
+export default modules.router;

--- a/packages/client/src/app/Routes.web.jsx
+++ b/packages/client/src/app/Routes.web.jsx
@@ -1,6 +1,0 @@
-import React from 'react';
-import { Switch } from 'react-router-dom';
-
-import modules from '../modules';
-
-export default <Switch>{modules.routes}</Switch>;

--- a/packages/client/src/modules/connector.js
+++ b/packages/client/src/modules/connector.js
@@ -6,7 +6,7 @@ export const featureCatalog = {};
 
 export default class {
   // eslint-disable-next-line no-unused-vars
-  constructor({ route, navItem, reducer, resolver, catalogInfo }, ...features) {
+  constructor({ route, navItem, reducer, resolver, routerFactory, catalogInfo }, ...features) {
     /* eslint-enable no-unused-vars */
     combine(arguments, arg => arg.catalogInfo).forEach(info =>
       Object.keys(info).forEach(key => (featureCatalog[key] = info[key]))
@@ -14,6 +14,9 @@ export default class {
     this.tabItem = combine(arguments, arg => arg.tabItem);
     this.reducer = combine(arguments, arg => arg.reducer);
     this.resolver = combine(arguments, arg => arg.resolver);
+    this.routerFactory = combine(arguments, arg => arg.routerFactory)
+      .slice(-1)
+      .pop();
   }
 
   get tabItems() {
@@ -26,5 +29,9 @@ export default class {
 
   get resolvers() {
     return merge(...this.resolver);
+  }
+
+  get router() {
+    return this.routerFactory();
   }
 }

--- a/packages/client/src/modules/connector.web.jsx
+++ b/packages/client/src/modules/connector.web.jsx
@@ -24,6 +24,7 @@ export default class {
       stylesInsert,
       scriptsInsert,
       rootComponentFactory,
+      routerFactory,
       catalogInfo
     },
     ...features
@@ -44,6 +45,13 @@ export default class {
     this.stylesInsert = combine(arguments, arg => arg.stylesInsert);
     this.scriptsInsert = combine(arguments, arg => arg.scriptsInsert);
     this.rootComponentFactory = combine(arguments, arg => arg.rootComponentFactory);
+    this.routerFactory = combine(arguments, arg => arg.routerFactory)
+      .slice(-1)
+      .pop();
+  }
+
+  get router() {
+    return this.routerFactory();
   }
 
   get routes() {

--- a/packages/client/src/modules/defaultRouter/index.native.jsx
+++ b/packages/client/src/modules/defaultRouter/index.native.jsx
@@ -1,0 +1,14 @@
+import { TabNavigator } from 'react-navigation';
+
+import modules from '../';
+
+import Feature from '../connector';
+
+const routerFactory = () =>
+  TabNavigator({
+    ...modules.tabItems
+  });
+
+export default new Feature({
+  routerFactory
+});

--- a/packages/client/src/modules/defaultRouter/index.web.jsx
+++ b/packages/client/src/modules/defaultRouter/index.web.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Switch } from 'react-router-dom';
+
+import modules from '../';
+
+import Feature from '../connector';
+
+const routerFactory = () => <Switch>{modules.routes}</Switch>;
+
+export default new Feature({
+  routerFactory
+});

--- a/packages/client/src/modules/index.js
+++ b/packages/client/src/modules/index.js
@@ -1,3 +1,4 @@
+import defaultRouter from './defaultRouter';
 import counter from './counter';
 import post from './post';
 import upload from './upload';
@@ -9,4 +10,4 @@ import './favicon';
 
 import Feature from './connector';
 
-export default new Feature(counter, post, upload, user, subscription, contact, pageNotFound);
+export default new Feature(defaultRouter, counter, post, upload, user, subscription, contact, pageNotFound);


### PR DESCRIPTION
Add a way to redefine app-wide router in a module. Only a single router will be used, the one that is imported last in a module list.
