### PR TITLE
Limits website middleware path matching of periods

### DIFF
--- a/packages/server/src/middleware/website.jsx
+++ b/packages/server/src/middleware/website.jsx
@@ -114,7 +114,7 @@ const renderServerSide = async (req, res) => {
 
 export default async (req, res, next) => {
   try {
-    if (req.url.indexOf('.') < 0 && __SSR__) {
+    if (req.path.indexOf('.') < 0 && __SSR__) {
       return await renderServerSide(req, res);
     } else {
       next();


### PR DESCRIPTION
The current implementation doesn't allow for path matching on routes such as: `/accounts/register/:token`, where token is a JWT that has a standard period in it.  

By changing the matcher to check for a period (dot) only inside of the path, this allows us to pass params containing periods in the query.