### PR TITLE
Fixed crash if createFetch is undefined

### DIFF
--- a/packages/client/src/app/Main.jsx
+++ b/packages/client/src/app/Main.jsx
@@ -69,7 +69,7 @@ const netLink = ApolloLink.split(
   new WebSocketLink(wsClient),
   new BatchHttpLink({
     fetch:
-      modules.createFetch(apiUrl) ||
+      (!!modules.createFetch && modules.createFetch(apiUrl)) ||
       createApolloFetch({
         uri: apiUrl,
         constructOptions: (reqs, options) => ({


### PR DESCRIPTION
This error is caused by delete the upload module, then createFetch will be undefined. Should do the undefined check