### PR TITLE
No loading sign if fetching more posts.

### DIFF
--- a/packages/client/src/modules/post/components/PostList.web.jsx
+++ b/packages/client/src/modules/post/components/PostList.web.jsx
@@ -54,7 +54,7 @@ class PostList extends React.PureComponent {
 
   render() {
     const { loading, posts, t } = this.props;
-    if (loading) {
+    if (loading && !posts) {
       return (
         <PageLayout>
           {this.renderMetaData()}


### PR DESCRIPTION
Do not show loading sign if you fetch more posts and some posts are already loaded.