### PR TITLE
Fix self referential deleteUser bug

### DIFF
--- a/packages/server/src/modules/user/resolvers.js
+++ b/packages/server/src/modules/user/resolvers.js
@@ -181,22 +181,27 @@ export default pubsub => ({
       (obj, args, { User, user }) => {
         return user.id !== args.id ? ['user:delete'] : ['user:delete:self'];
       },
-      async (obj, { id }, { User, req: { t } }) => {
+      async (obj, { id }, context) => {
+        const { User, req: { t } } = context;
+        const isAdmin = () => context.user.role === 'admin';
+        const isSelf = () => context.user.id === id;
+
         try {
           const e = new FieldError();
           const user = await User.getUser(id);
+
           if (!user) {
             e.setError('delete', t('user:userIsNotExisted'));
-
             e.throwIf();
           }
 
-          if (user.id === user.id) {
+          if (isSelf()) {
             e.setError('delete', t('user:userCannotDeleteYourself'));
             e.throwIf();
           }
 
-          const isDeleted = await User.deleteUser(id);
+          const isDeleted = !isSelf() && isAdmin() ? await User.deleteUser(id) : false;
+
           if (isDeleted) {
             pubsub.publish(USERS_SUBSCRIPTION, {
               usersUpdated: {


### PR DESCRIPTION
The deleteUser method arguments were recently destructured. In the process, the context user was removed due to a naming conflict with the targeted deletion user. Consequently, the expression: `user.id === user.id` always referenced the same user, thereby always raising the error that prevents users from deleting themselves. I also refactored slightly to mimic the pattern of other methods in the file.