### PR TITLE
Fix interoperability issues between tslint and eslint

### DIFF
--- a/.eslintrc.base.json
+++ b/.eslintrc.base.json
@@ -8,6 +8,16 @@
   ],
   "rules": {
     "import/no-extraneous-dependencies": ["error", {"optionalDependencies": true}],
+    "import/extensions": [
+      "error",
+      "always",
+      {
+        "js": "never",
+        "jsx": "never",
+        "ts": "never",
+        "tsx": "never"
+      }
+    ],
     "no-use-before-define": 0,
     "arrow-body-style": 0,
     "dot-notation": 0,

--- a/packages/common/.eslintrc
+++ b/packages/common/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "extends": "../../.eslintrc.base.json",
+  "settings": {
+    "import/resolver": {
+      "webpack": {
+        "config": "webpack.config.lint.js"
+      }
+    }
+  }
+}

--- a/packages/common/webpack.config.lint.js
+++ b/packages/common/webpack.config.lint.js
@@ -1,0 +1,1 @@
+module.exports = require('../client/webpack.config.lint');

--- a/tslint.json
+++ b/tslint.json
@@ -65,6 +65,7 @@
     "no-var-keyword": true,
     "no-var-requires": true,
     "object-literal-sort-keys": false,
+    "ordered-imports": false,
     "radix": true,
     "switch-default": true,
     "triple-equals": [true, "allow-null-check"],


### PR DESCRIPTION
Currently if you rename one file with heavy usage in `packages/client` you will fall into interoperability issues between `tslint` and `eslint`. First - `eslint` doesn't allow to import from files ending with `ts`. Second, because proper `.eslintrc` is not preset in `packages/common` - import resolution in this folder is only possible for only very basic cases, for advanced cases when webpack config should be used - it will not work out well, because of the bugs in webpack import plugin for eslint, we should configure webpack resolution for `packages/common` the same way we do for all other packages, to avoid these problems.