### PR TITLE
Run prittier on files changed by cli

### DIFF
--- a/tools/cli/commands/addModule.js
+++ b/tools/cli/commands/addModule.js
@@ -1,7 +1,7 @@
 const shell = require('shelljs');
 const fs = require('fs');
 const chalk = require('chalk');
-const { copyFiles, renameFiles, computeModulesPath } = require('../helpers/util');
+const { copyFiles, renameFiles, computeModulesPath, runPrittier } = require('../helpers/util');
 
 /**
  * Adds module in client or server and adds a new module to the Feature connector.
@@ -52,6 +52,7 @@ function addModule(logger, templatesPath, moduleName, location, finished = true)
   shell
     .ShellString(indexContent.replace(RegExp(featureRegExp, 'g'), `Feature(${moduleName}, ${featureModules})`))
     .to(indexPath);
+  runPrittier(indexPath);
 
   if (finished) {
     logger.info(chalk.green(`✔ Module for ${location} successfully created!`));

--- a/tools/cli/commands/deleteModule.js
+++ b/tools/cli/commands/deleteModule.js
@@ -1,7 +1,7 @@
 const shell = require('shelljs');
 const fs = require('fs');
 const chalk = require('chalk');
-const { computeModulesPath } = require('../helpers/util');
+const { computeModulesPath, runPrittier } = require('../helpers/util');
 
 /**
  * Removes the module from client, server or both locations and removes the module from the Feature connector.
@@ -47,6 +47,7 @@ function deleteModule(logger, moduleName, location) {
       .replace(RegExp(`import ${moduleName} from './${moduleName}';\n`, 'g'), '');
 
     fs.writeFileSync(indexPath, contentWithoutDeletedModule);
+    runPrittier(indexPath);
 
     logger.info(chalk.green(`✔ Module for ${location} successfully deleted!`));
   } else {

--- a/tools/cli/helpers/util.js
+++ b/tools/cli/helpers/util.js
@@ -1,4 +1,5 @@
 const shell = require('shelljs');
+const fs = require('fs');
 const { pascalize, decamelize } = require('humps');
 const { startCase } = require('lodash');
 const { BASE_PATH } = require('../config');
@@ -56,8 +57,20 @@ function computeModulesPath(location, moduleName = '') {
   return `${BASE_PATH}/packages/${location}/src/modules/${moduleName}`;
 }
 
+/**
+ * Run prettier on file that was changed.
+ *
+ * @param pathToFile
+ */
+function runPrittier(pathToFile) {
+  if (fs.existsSync(pathToFile)) {
+    shell.exec(`prettier --print-width 120 --single-quote --loglevel error --write ${pathToFile}`);
+  }
+}
+
 module.exports = {
   renameFiles,
   copyFiles,
-  computeModulesPath
+  computeModulesPath,
+  runPrittier
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6714,7 +6714,7 @@ graphql-tools@^3.0.4:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
-graphql@^0.13.0:
+graphql@0.13.2, graphql@^0.13.0:
   version "0.13.2"
   resolved "http://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
   dependencies:
@@ -7879,7 +7879,7 @@ items@2.x.x:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/items/-/items-2.1.1.tgz#8bd16d9c83b19529de5aea321acaada78364a198"
 
-iterall@^1.1.3, iterall@^1.2.1:
+iterall@^1.1.3, iterall@^1.2.1, iterall@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
 
@@ -14334,7 +14334,7 @@ unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
-upath@^1.0.5:
+upath@^1.0.5, upath@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 


### PR DESCRIPTION
Every time you run a cli command and a file is changed, you might not get the file formatted exactly like prettier wants, so if you add and delete a module, you get some files changed, but only formatting is off.

This PR tries to resolve this per file, since it takes a while to run prettier on all files and for some reason not all files get reformatted, unless you explicitly set it.