### PR TITLE
Update creation of redux store

### DIFF
--- a/packages/client/src/app/Main.tsx
+++ b/packages/client/src/app/Main.tsx
@@ -7,7 +7,7 @@ import ReactGA from 'react-ga';
 
 import RedBox from './RedBox';
 import createApolloClient from '../../../common/createApolloClient';
-import createReduxStore, { storeReducer } from '../../../common/createReduxStore';
+import createReduxStore, { getStoreReducer } from '../../../common/createReduxStore';
 import Routes from './Routes';
 import modules from '../modules';
 import log from '../../../common/log';
@@ -38,9 +38,9 @@ history.listen(location => logPageView(location));
 
 if (module.hot && module.hot.data && module.hot.data.store) {
   store = module.hot.data.store;
-  store.replaceReducer(storeReducer);
+  store.replaceReducer(getStoreReducer(modules.reducers));
 } else {
-  store = createReduxStore({}, client, routerMiddleware(history));
+  store = createReduxStore(modules.reducers, {}, client, routerMiddleware(history));
 }
 
 if (module.hot) {

--- a/packages/common/createReduxStore.js
+++ b/packages/common/createReduxStore.js
@@ -2,16 +2,15 @@ import { createStore, combineReducers, applyMiddleware } from 'redux';
 import { routerReducer } from 'react-router-redux';
 import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
 
-import modules from '../client/src/modules';
+export const getStoreReducer = reducers =>
+  combineReducers({
+    router: routerReducer,
+    ...reducers
+  });
 
-export const storeReducer = combineReducers({
-  router: routerReducer,
-  ...modules.reducers
-});
-
-const createReduxStore = (initialState, client, routerMiddleware) => {
+const createReduxStore = (reducers, initialState, client, routerMiddleware) => {
   return createStore(
-    storeReducer,
+    getStoreReducer(reducers),
     initialState, // initial state
     routerMiddleware ? composeWithDevTools(applyMiddleware(routerMiddleware)) : undefined
   );

--- a/packages/server/src/middleware/website.tsx
+++ b/packages/server/src/middleware/website.tsx
@@ -85,7 +85,7 @@ const renderServerSide = async (req: any, res: any) => {
     clientResolvers: clientModules.resolvers,
     connectionParams: null
   });
-  const store = createReduxStore({}, client);
+  const store = createReduxStore(clientModules.reducers, {}, client);
   const context: any = {};
   const App = clientModules.getWrappedRoot(
     <Provider store={store}>


### PR DESCRIPTION
Add functionality for passing reducers into `createReduxStore` function instead of importing `modules`  in `common` package