### PR TITLE
Improve graphql subscriptions mechanism [Scala]

### DIFF
--- a/modules/core/server-scala/src/main/resources/application.conf
+++ b/modules/core/server-scala/src/main/resources/application.conf
@@ -6,6 +6,9 @@ app {
 akka.http {
   server {
     default-http-port = 8080
+    websocket {
+      periodic-keep-alive-max-idle = 1 second
+    }
   }
   session {
     server-secret = "c05ll3lesrinf39t7mc5h6un6r0c69lgfno69jktk3vabeqamouq4328cuaekros401ajdp0sysgears8ro24rbumgtnd1ebag6ljn825i8a55d482ok7o0nch0bfbe"

--- a/modules/core/server-scala/src/main/scala/core/services/publisher/PubSubServiceImpl.scala
+++ b/modules/core/server-scala/src/main/scala/core/services/publisher/PubSubServiceImpl.scala
@@ -5,15 +5,14 @@ import akka.stream.scaladsl.Source
 import common.Logger
 import javax.inject.{Inject, Singleton}
 import monix.execution.Scheduler
-import monix.reactive.OverflowStrategy
-import monix.reactive.subjects.ConcurrentSubject
+import monix.reactive.subjects.PublishSubject
 import sangria.schema.Action
 
 @Singleton
 class PubSubServiceImpl[T] @Inject()(implicit val scheduler: Scheduler) extends PubSubService[T]
   with Logger {
 
-  lazy val source: ConcurrentSubject[T, T] = ConcurrentSubject.publish[T](OverflowStrategy.DropOld(16))
+  private lazy val source = PublishSubject[T]
 
   override def publish(event: T): Unit = source.onNext(event)
 


### PR DESCRIPTION
It is necessary to add a parameter for holding the websocket connection and change an implementation of monix subscriptions on more suitable for the concrete situation - to emit to a subscriber-only those items that are emitted by the source subsequent to the time of the subscription.