### PR TITLE
Use sangria UserFacingError instead of "onException" method in dispatcher resolver [Scala]

### DIFF
--- a/modules/core/server-scala/src/main/scala/common/actors/Dispatcher.scala
+++ b/modules/core/server-scala/src/main/scala/common/actors/Dispatcher.scala
@@ -3,9 +3,8 @@ package common.actors
 import akka.actor.{Actor, ActorLogging, ActorRef, Status}
 import akka.pattern._
 import akka.stream.ActorMaterializer
-import common.implicits.RichList._
 import common.actors.Dispatcher.{DispatcherMessage, Failure, InterceptorBeforeMessage, Success}
-import common.errors.Error
+import common.implicits.RichList._
 import common.{ActorMessageDelivering, ActorNamed}
 import core.graphql.UserContext
 import javax.inject.Inject
@@ -17,13 +16,7 @@ object Dispatcher extends ActorNamed {
 
   final val name = "Dispatcher"
 
-  final case class DispatcherMessage(input: Any,
-                                     context: UserContext,
-                                     replyTo: ActorRef,
-                                     resolverActor: ActorRef,
-                                     onException: Exception => Any,
-                                     before: List[ActorRef] = Nil,
-                                     after: List[ActorRef] = Nil)
+  final case class DispatcherMessage(input: Any, context: UserContext, replyTo: ActorRef, resolverActor: ActorRef, before: List[ActorRef] = Nil, after: List[ActorRef] = Nil)
 
   final case class InterceptorBeforeMessage(input: Any,
                                             context: UserContext,
@@ -64,8 +57,7 @@ class Dispatcher @Inject()(implicit actorMaterializer: ActorMaterializer,
       } else {
         sendMessageToActor[Any](msg.resolverActor, msg.input).andThen {
           case scala.util.Success(r) => msg.replyTo ! r
-          case scala.util.Failure(f: Error) => msg.replyTo ! msg.onException(f)
-          case scala.util.Failure(f) ⇒ msg.replyTo ! Status.Failure(f)
+          case scala.util.Failure(f) => msg.replyTo ! Status.Failure(f)
         }
       }
   }
@@ -78,6 +70,6 @@ class Dispatcher @Inject()(implicit actorMaterializer: ActorMaterializer,
 
     case Failure(e) =>
       log.info(s"Interceptor has finished with failure. Reason: '$e'")
-      msg.replyTo ! msg.onException(e)
+      msg.replyTo ! Status.Failure(e)
   }
 }

--- a/modules/core/server-scala/src/main/scala/common/errors/Error.scala
+++ b/modules/core/server-scala/src/main/scala/common/errors/Error.scala
@@ -1,3 +1,5 @@
 package common.errors
 
-class Error(msg: String = "") extends Exception(msg)
+import sangria.execution.UserFacingError
+
+class Error(msg: String = "") extends Exception(msg) with UserFacingError

--- a/modules/core/server-scala/src/main/scala/common/graphql/DispatcherResolver.scala
+++ b/modules/core/server-scala/src/main/scala/common/graphql/DispatcherResolver.scala
@@ -2,9 +2,9 @@ package common.graphql
 
 import akka.actor.{ActorRef, ActorSystem}
 import akka.stream.ActorMaterializer
-import common.{ActorMessageDelivering, ActorNamed}
 import common.actors.Dispatcher
 import common.actors.Dispatcher.DispatcherMessage
+import common.{ActorMessageDelivering, ActorNamed}
 import core.graphql.UserContext
 import core.guice.injection.GuiceActorRefProvider
 
@@ -16,7 +16,6 @@ object DispatcherResolver extends ActorMessageDelivering
   def resolveWithDispatcher[T](input: Any,
                                userContext: UserContext,
                                namedResolverActor: ActorNamed,
-                               onException: Exception => Any,
                                before: List[ActorRef] = Nil,
                                after: List[ActorRef] = Nil)
                               (implicit actorSystem: ActorSystem,
@@ -24,15 +23,7 @@ object DispatcherResolver extends ActorMessageDelivering
 
     sendMessageWithFunc[T] {
       replyTo =>
-        provideActorRef(Dispatcher) ! DispatcherMessage(
-          input,
-          userContext,
-          replyTo,
-          provideActorRef(namedResolverActor),
-          onException,
-          before,
-          after
-        )
+        provideActorRef(Dispatcher) ! DispatcherMessage(input, userContext, replyTo, provideActorRef(namedResolverActor), before, after)
     }
   }
 }

--- a/modules/counter/server-scala/src/main/scala/graphql/schema/CounterSchema.scala
+++ b/modules/counter/server-scala/src/main/scala/graphql/schema/CounterSchema.scala
@@ -34,7 +34,6 @@ class CounterSchema @Inject()(implicit val pubsubService: PubSubService[Counter]
       resolve = sc => resolveWithDispatcher[Counter](
         input = GetAmount,
         userContext = sc.ctx,
-        onException = _ => Counter(amount = 0),
         namedResolverActor = CounterResolver
       )
     )
@@ -50,7 +49,6 @@ class CounterSchema @Inject()(implicit val pubsubService: PubSubService[Counter]
         resolveWithDispatcher[Counter](
           input = amount,
           userContext = sc.ctx,
-          onException = _ => Counter(amount = 0),
           namedResolverActor = CounterResolver
         ).pub
       }

--- a/modules/pagination/server-scala/src/main/scala/graphql/schema/ItemSchema.scala
+++ b/modules/pagination/server-scala/src/main/scala/graphql/schema/ItemSchema.scala
@@ -7,8 +7,7 @@ import common.{InputUnmarshallerGenerator, Logger}
 import core.graphql.{GraphQLSchema, UserContext}
 import graphql.resolvers.ItemResolver
 import javax.inject.Inject
-import model.PaginationParams
-import model.{Item, ItemsPayload}
+import model.{Item, ItemsPayload, PaginationParams}
 import sangria.macros.derive._
 import sangria.marshalling.FromInput
 import sangria.schema.{Argument, Field, InputObjectType, ObjectType}
@@ -55,7 +54,6 @@ class ItemSchema @Inject()(implicit val materializer: ActorMaterializer,
         resolveWithDispatcher[ItemsPayload](
           input = sc.args.arg[PaginationParams]("input"),
           userContext = sc.ctx,
-          onException = _ => PaginationParams(offset = 0, limit = 1),
           namedResolverActor = ItemResolver
         )
       }

--- a/modules/user/server-scala/src/main/scala/graphql/schema/TokenSchema.scala
+++ b/modules/user/server-scala/src/main/scala/graphql/schema/TokenSchema.scala
@@ -11,8 +11,6 @@ import model.Tokens
 import sangria.macros.derive.{ObjectTypeName, deriveObjectType}
 import sangria.schema.{Argument, Field, ObjectType, StringType}
 
-import scala.concurrent.Future
-
 class TokenSchema @Inject()(implicit val materializer: ActorMaterializer,
                             actorSystem: ActorSystem) extends GraphQLSchema
   with InputUnmarshallerGenerator
@@ -28,7 +26,6 @@ class TokenSchema @Inject()(implicit val materializer: ActorMaterializer,
       resolve = sc => resolveWithDispatcher[Tokens](
         input = sc.args.arg[String]("refreshToken"),
         userContext = sc.ctx,
-        onException = _ => Tokens("", ""),
         namedResolverActor = TokenResolver
       )
     )

--- a/modules/user/server-scala/src/main/scala/graphql/schema/UserSchema.scala
+++ b/modules/user/server-scala/src/main/scala/graphql/schema/UserSchema.scala
@@ -2,19 +2,16 @@ package graphql.schema
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import common.{InputUnmarshallerGenerator, Logger}
 import common.graphql.DispatcherResolver._
+import common.{InputUnmarshallerGenerator, Logger}
 import config.AuthConfig
 import core.graphql.{GraphQLSchema, UserContext}
-import javax.inject.Inject
 import graphql.resolvers.UserResolver
+import javax.inject.Inject
 import model.{UserPayload, _}
-import modules.common.FieldError
-import sangria.schema.{Argument, Field, InputObjectType, ObjectType, StringType}
 import sangria.macros.derive._
 import sangria.marshalling.FromInput
-
-import scala.concurrent.Future
+import sangria.schema.{Argument, Field, InputObjectType, ObjectType, StringType}
 
 class UserSchema @Inject()(authConfig: AuthConfig)
                           (implicit val materializer: ActorMaterializer,
@@ -89,7 +86,6 @@ class UserSchema @Inject()(authConfig: AuthConfig)
       resolve = sc => resolveWithDispatcher[UserPayload](
         input = (sc.args.arg[RegisterUserInput]("input"), authConfig.skipConfirmation),
         userContext = sc.ctx,
-        onException = e => UserPayload(errors = Some(List(FieldError("register", e.getMessage)))),
         namedResolverActor = UserResolver
       )
     ),
@@ -100,7 +96,6 @@ class UserSchema @Inject()(authConfig: AuthConfig)
       resolve = sc => resolveWithDispatcher[AuthPayload](
         input = sc.args.arg[ConfirmRegistrationInput]("input"),
         userContext = sc.ctx,
-        onException = e => AuthPayload(errors = Some(List(FieldError("confirmRegistration", e.getMessage)))),
         namedResolverActor = UserResolver
       )
     ),
@@ -111,7 +106,6 @@ class UserSchema @Inject()(authConfig: AuthConfig)
       resolve = sc => resolveWithDispatcher[UserPayload](
         input = sc.args.arg[ResendConfirmationMessageInput]("input"),
         userContext = sc.ctx,
-        onException = e => UserPayload(errors = Some(List(FieldError("resendConfirmationMessage", e.getMessage)))),
         namedResolverActor = UserResolver
       )
     ),
@@ -122,7 +116,6 @@ class UserSchema @Inject()(authConfig: AuthConfig)
       resolve = sc => resolveWithDispatcher[AuthPayload](
         input = sc.args.arg[LoginUserInput]("input"),
         userContext = sc.ctx,
-        onException = e => AuthPayload(errors = Some(List(FieldError("login", e.getMessage)))),
         namedResolverActor = UserResolver
       )
     ),
@@ -133,7 +126,6 @@ class UserSchema @Inject()(authConfig: AuthConfig)
       resolve = sc => resolveWithDispatcher[String](
         input = sc.args.arg[ForgotPasswordInput]("input"),
         userContext = sc.ctx,
-        onException = e => Future.failed(e),
         namedResolverActor = UserResolver
       )
     ),
@@ -144,7 +136,6 @@ class UserSchema @Inject()(authConfig: AuthConfig)
       resolve = sc => resolveWithDispatcher[ResetPayload](
         input = sc.args.arg[ResetPasswordInput]("input"),
         userContext = sc.ctx,
-        onException = e => ResetPayload(errors = Some(List(FieldError("resetPassword", e.getMessage)))),
         namedResolverActor = UserResolver
       )
     )

--- a/modules/user/server-scala/src/main/scala/graphql/schema/UserSchema.scala
+++ b/modules/user/server-scala/src/main/scala/graphql/schema/UserSchema.scala
@@ -2,20 +2,17 @@ package graphql.schema
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import common.{InputUnmarshallerGenerator, Logger}
 import common.graphql.DispatcherResolver._
+import common.{InputUnmarshallerGenerator, Logger}
 import config.AuthConfig
 import core.graphql.{GraphQLSchema, UserContext}
-import javax.inject.Inject
 import graphql.resolvers.UserResolver
+import javax.inject.Inject
 import model.{UserPayload, _}
-import modules.common.FieldError
 import modules.jwt.model.Tokens
-import sangria.schema.{Argument, Field, InputObjectType, ObjectType, StringType}
 import sangria.macros.derive._
 import sangria.marshalling.FromInput
-
-import scala.concurrent.Future
+import sangria.schema.{Argument, Field, InputObjectType, ObjectType, StringType}
 
 class UserSchema @Inject()(authConfig: AuthConfig)
                           (implicit val materializer: ActorMaterializer,
@@ -90,7 +87,6 @@ class UserSchema @Inject()(authConfig: AuthConfig)
       resolve = sc => resolveWithDispatcher[UserPayload](
         input = (sc.args.arg[RegisterUserInput]("input"), authConfig.skipConfirmation),
         userContext = sc.ctx,
-        onException = e => UserPayload(errors = Some(List(FieldError("register", e.getMessage)))),
         namedResolverActor = UserResolver
       )
     ),
@@ -101,7 +97,6 @@ class UserSchema @Inject()(authConfig: AuthConfig)
       resolve = sc => resolveWithDispatcher[AuthPayload](
         input = sc.args.arg[ConfirmRegistrationInput]("input"),
         userContext = sc.ctx,
-        onException = e => AuthPayload(errors = Some(List(FieldError("confirmRegistration", e.getMessage)))),
         namedResolverActor = UserResolver
       )
     ),
@@ -112,7 +107,6 @@ class UserSchema @Inject()(authConfig: AuthConfig)
       resolve = sc => resolveWithDispatcher[UserPayload](
         input = sc.args.arg[ResendConfirmationMessageInput]("input"),
         userContext = sc.ctx,
-        onException = e => UserPayload(errors = Some(List(FieldError("resendConfirmationMessage", e.getMessage)))),
         namedResolverActor = UserResolver
       )
     ),
@@ -123,7 +117,6 @@ class UserSchema @Inject()(authConfig: AuthConfig)
       resolve = sc => resolveWithDispatcher[AuthPayload](
         input = sc.args.arg[LoginUserInput]("input"),
         userContext = sc.ctx,
-        onException = e => AuthPayload(errors = Some(List(FieldError("login", e.getMessage)))),
         namedResolverActor = UserResolver
       )
     ),
@@ -134,7 +127,6 @@ class UserSchema @Inject()(authConfig: AuthConfig)
       resolve = sc => resolveWithDispatcher[String](
         input = sc.args.arg[ForgotPasswordInput]("input"),
         userContext = sc.ctx,
-        onException = e => Future.failed(e),
         namedResolverActor = UserResolver
       )
     ),
@@ -145,7 +137,6 @@ class UserSchema @Inject()(authConfig: AuthConfig)
       resolve = sc => resolveWithDispatcher[ResetPayload](
         input = sc.args.arg[ResetPasswordInput]("input"),
         userContext = sc.ctx,
-        onException = e => ResetPayload(errors = Some(List(FieldError("resetPassword", e.getMessage)))),
         namedResolverActor = UserResolver
       )
     )


### PR DESCRIPTION
It is necessary to remove "onException" method in Dispatcher Resolver and use sangria UserFacingError trait for errors in resolvers