### PR TITLE
Add env variable for disabling waiting backend on the client side [Scala]

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean": "lerna run clean --stream",
     "start": "lerna run --scope=server start --stream",
     "watch": "spin watch",
-    "watch-client": "cross-env DISABLE_SSR=true lerna run --scope=client watch --stream",
+    "watch-client": "cross-env DISABLE_SSR=true DISABLE_WAITING_BACKEND=true lerna run --scope=client watch --stream",
     "cli": "node tools/cli",
     "stripe:setup": "lerna run --scope=server stripe:setup",
     "seed": "lerna run --scope=server seed --stream",

--- a/packages/client/.spinrc.js
+++ b/packages/client/.spinrc.js
@@ -11,7 +11,7 @@ const config = {
         __CLIENT__: true
       },
       // Wait for backend to start prior to letting webpack load frontend page
-      waitOn: ['tcp:localhost:8080'],
+      waitOn: !process.env.DISABLE_WAITING_BACKEND ? ['tcp:localhost:8080']: [],
       enabled: true
     },
     test: {


### PR DESCRIPTION
This pull request provides disabling  waiting back-end ( in spinrc.js) with env variable in the `yarn watch-client` command for the Scala team.