### PR TITLE
Fix problem of serving all static files as index.html when SSR is disabled

### DIFF
--- a/modules/core/server-ts/middleware/website.tsx
+++ b/modules/core/server-ts/middleware/website.tsx
@@ -142,7 +142,7 @@ export default (schema: GraphQLSchema, modules: ServerModule) => async (
   try {
     if (req.path.indexOf('.') < 0 && __SSR__) {
       return await renderServerSide(req, res, schema, modules);
-    } else if (!__SSR__ && req.method === 'GET') {
+    } else if (req.path.indexOf('.') < 0 && !__SSR__ && req.method === 'GET') {
       res.sendFile(path.resolve(__FRONTEND_BUILD_DIR__, 'index.html'));
     } else {
       next();


### PR DESCRIPTION
Since we are using req.path.indexOf('.') < 0 to check if the server is serving static files such as *.jpg *.css *.js , when SSR is disabled we still need to check it, otherwise the server will be responding with the content of index.html to any static file requests.