### PR TITLE
Remove the extra padding on top of every screen in iOS app

### DIFF
--- a/modules/chat/client-react/index.native.tsx
+++ b/modules/chat/client-react/index.native.tsx
@@ -20,7 +20,8 @@ export default new ClientModule({
               headerTitle: <HeaderTitleWithI18n style="subTitle" />,
               headerLeft: (
                 <IconButton iconName="menu" iconSize={32} iconColor="#0275d8" onPress={() => navigation.openDrawer()} />
-              )
+              ),
+              headerForceInset: {}
             })
           }
         }),

--- a/modules/contact/client-react/index.native.tsx
+++ b/modules/contact/client-react/index.native.tsx
@@ -22,7 +22,8 @@ export default new ClientModule({
               headerLeft: (
                 <IconButton iconName="menu" iconSize={32} iconColor="#0275d8" onPress={() => navigation.openDrawer()} />
               ),
-              headerStyle: { backgroundColor: '#fff' }
+              headerStyle: { backgroundColor: '#fff' },
+              headerForceInset: {}
             })
           }
         }),

--- a/modules/counter/client-react/index.native.tsx
+++ b/modules/counter/client-react/index.native.tsx
@@ -22,7 +22,8 @@ export default new ClientModule(counters, {
               headerLeft: (
                 <IconButton iconName="menu" iconSize={32} iconColor="#0275d8" onPress={() => navigation.openDrawer()} />
               ),
-              headerStyle: { backgroundColor: '#fff' }
+              headerStyle: { backgroundColor: '#fff' },
+              headerForceInset: {}
             })
           }
         }),

--- a/modules/pagination/client-react/index.native.jsx
+++ b/modules/pagination/client-react/index.native.jsx
@@ -20,7 +20,8 @@ export default new ClientModule({
               headerTitle: <HeaderTitleWithI18n style="subTitle" />,
               headerLeft: (
                 <IconButton iconName="menu" iconSize={32} iconColor="#0275d8" onPress={() => navigation.openDrawer()} />
-              )
+              ),
+              headerForceInset: {}
             })
           }
         }),

--- a/modules/post/client-react/index.native.jsx
+++ b/modules/post/client-react/index.native.jsx
@@ -39,7 +39,8 @@ class PostListScreen extends React.Component {
     headerLeft: (
       <IconButton iconName="menu" iconSize={32} iconColor="#0275d8" onPress={() => navigation.openDrawer()} />
     ),
-    headerStyle: styles.header
+    headerStyle: styles.header,
+    headerForceInset: {}
   });
 
   render() {
@@ -74,7 +75,8 @@ PostAddTitle.propTypes = {
 class PostEditScreen extends React.Component {
   static navigationOptions = ({ navigation }) => ({
     headerTitle: withI18N(PostEditTitle, { navigation }),
-    headerStyle: styles.header
+    headerStyle: styles.header,
+    headerForceInset: {}
   });
 
   render() {
@@ -88,7 +90,8 @@ PostEditScreen.propTypes = {
 class PostAddScreen extends React.Component {
   static navigationOptions = ({ navigation }) => ({
     headerTitle: withI18N(PostAddTitle, { navigation }),
-    headerStyle: styles.header
+    headerStyle: styles.header,
+    headerForceInset: {}
   });
 
   render() {

--- a/modules/upload/client-react/index.native.jsx
+++ b/modules/upload/client-react/index.native.jsx
@@ -23,7 +23,8 @@ export default new ClientModule({
               headerLeft: (
                 <IconButton iconName="menu" iconSize={32} iconColor="#0275d8" onPress={() => navigation.openDrawer()} />
               ),
-              headerStyle: { backgroundColor: '#fff' }
+              headerStyle: { backgroundColor: '#fff' },
+              headerForceInset: {}
             })
           }
         }),

--- a/modules/user/client-react/index.native.jsx
+++ b/modules/user/client-react/index.native.jsx
@@ -23,7 +23,10 @@ export { default as CURRENT_USER_QUERY } from './graphql/CurrentUserQuery.graphq
 class LoginScreen extends React.Component {
   static navigationOptions = ({ navigation }) => ({
     headerTitle: <HeaderTitleWithI18n i18nKey="navLink.signIn" style="subTitle" />,
-    headerLeft: <IconButton iconName="menu" iconSize={32} iconColor="#0275d8" onPress={() => navigation.openDrawer()} />
+    headerLeft: (
+      <IconButton iconName="menu" iconSize={32} iconColor="#0275d8" onPress={() => navigation.openDrawer()} />
+    ),
+    headerForceInset: {}
   });
 
   render() {
@@ -37,7 +40,8 @@ LoginScreen.propTypes = {
 
 class ForgotPasswordScreen extends React.Component {
   static navigationOptions = () => ({
-    headerTitle: <HeaderTitleWithI18n i18nKey="navLink.forgotPassword" style="subTitle" />
+    headerTitle: <HeaderTitleWithI18n i18nKey="navLink.forgotPassword" style="subTitle" />,
+    headerForceInset: {}
   });
   render() {
     return <ForgotPassword navigation={this.props.navigation} />;
@@ -50,7 +54,8 @@ ForgotPasswordScreen.propTypes = {
 
 class RegisterScreen extends React.Component {
   static navigationOptions = () => ({
-    headerTitle: <HeaderTitleWithI18n i18nKey="navLink.register" style="subTitle" />
+    headerTitle: <HeaderTitleWithI18n i18nKey="navLink.register" style="subTitle" />,
+    headerForceInset: {}
   });
   render() {
     return <Register navigation={this.props.navigation} />;
@@ -159,13 +164,15 @@ export default new ClientModule({
               headerTitle: <HeaderTitleWithI18n i18nKey="navLink.profile" style="subTitle" />,
               headerLeft: (
                 <IconButton iconName="menu" iconSize={32} iconColor="#0275d8" onPress={() => navigation.openDrawer()} />
-              )
+              ),
+              headerForceInset: {}
             })
           },
           ProfileEdit: {
             screen: ProfilerEditScreen,
             navigationOptions: () => ({
-              headerTitle: <HeaderTitleWithI18n i18nKey="navLink.editProfile" style="subTitle" />
+              headerTitle: <HeaderTitleWithI18n i18nKey="navLink.editProfile" style="subTitle" />,
+              headerForceInset: {}
             })
           }
         }),
@@ -205,19 +212,22 @@ export default new ClientModule({
                     navigation.setParams({ isOpenFilter: !isOpenFilter });
                   }}
                 />
-              )
+              ),
+              headerForceInset: {}
             })
           },
           UserEdit: {
             screen: UserEditScreen,
             navigationOptions: () => ({
-              headerTitle: <HeaderTitleWithI18n i18nKey="navLink.editUser" style="subTitle" />
+              headerTitle: <HeaderTitleWithI18n i18nKey="navLink.editUser" style="subTitle" />,
+              headerForceInset: {}
             })
           },
           UserAdd: {
             screen: UserAddScreen,
             navigationOptions: () => ({
-              headerTitle: <HeaderTitleWithI18n i18nKey="navLink.editUser" style="subTitle" />
+              headerTitle: <HeaderTitleWithI18n i18nKey="navLink.editUser" style="subTitle" />,
+              headerForceInset: {}
             })
           }
         }),


### PR DESCRIPTION
Before fix:
<img width="340" alt="before" src="https://user-images.githubusercontent.com/229229/55842194-849ae600-5b86-11e9-8fed-3933fe30b93d.png">

After fix:
<img width="339" alt="after" src="https://user-images.githubusercontent.com/229229/55842196-8664a980-5b86-11e9-926b-92715b026ba1.png">

Please have a look at [this issue](https://github.com/react-navigation/react-navigation/pull/3633) to get an idea of why we need to fix in this way. Basically:

* react-native has improved the implementation of ``<SafeAreaView>``, but react-navigation has hardcoded ``forceInset`` prop value which no longer works correctly
* someone noted this hardcoded ``forceInset`` prop value caused unremovable padding on top, and suggested it should be removed
* the maintainer of react-navigation prefers making this prop customizable while preserving its hardcoded value: https://github.com/react-navigation/react-navigation-stack/blob/master/src/views/Header/Header.js#L605

That's why we need to customize the ``forceInset`` prop (effectively removing it).

Hopefully anyone who starts his/her own project based on this codebase would no longer have to figure out first thing how to remove the padding on top :)