### PR TITLE
Integrate `react-apollo-hooks` into the kit #1043

### DIFF
--- a/modules/core/client-react/Main.tsx
+++ b/modules/core/client-react/Main.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ApolloProvider } from 'react-apollo';
+import { ApolloProvider as ApolloHooksProvider } from 'react-apollo-hooks';
 import { ApolloClient } from 'apollo-client';
 import { Store } from 'redux';
 import { Provider } from 'react-redux';
@@ -90,7 +91,9 @@ export class Main extends React.Component<any, MainState> {
       ref.modules.getWrappedRoot(
         <Provider store={ref.store}>
           <ApolloProvider client={ref.client}>
-            {ref.modules.getDataRoot(<ConnectedRouter history={history}>{ref.modules.router}</ConnectedRouter>)}
+            <ApolloHooksProvider client={ref.client}>
+              {ref.modules.getDataRoot(<ConnectedRouter history={history}>{ref.modules.router}</ConnectedRouter>)}
+            </ApolloHooksProvider>
           </ApolloProvider>
         </Provider>
       )

--- a/modules/core/server-ts/middleware/website.tsx
+++ b/modules/core/server-ts/middleware/website.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { SchemaLink } from 'apollo-link-schema';
 import { ApolloProvider, getDataFromTree } from 'react-apollo';
+import { ApolloProvider as ApolloHooksProvider } from 'react-apollo-hooks';
 import { Provider } from 'react-redux';
 import { StaticRouter } from 'react-router';
 import { ServerStyleSheet } from 'styled-components';
@@ -99,11 +100,13 @@ const renderServerSide = async (req: any, res: any, schema: GraphQLSchema, modul
   const App = clientModules.getWrappedRoot(
     <Provider store={store}>
       <ApolloProvider client={client}>
-        {clientModules.getDataRoot(
-          <StaticRouter location={req.url} context={context}>
-            {clientModules.router}
-          </StaticRouter>
-        )}
+        <ApolloHooksProvider client={client}>
+          {clientModules.getDataRoot(
+            <StaticRouter location={req.url} context={context}>
+              {clientModules.router}
+            </StaticRouter>
+          )}
+        </ApolloHooksProvider>
       </ApolloProvider>
     </Provider>,
     req

--- a/modules/counter/client-react/clientCounter/containers/ClientCounter.tsx
+++ b/modules/counter/client-react/clientCounter/containers/ClientCounter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Mutation, Query, MutationFn } from 'react-apollo';
+import { useQuery, useMutation } from 'react-apollo-hooks';
 
 import { ClientCounterButton, ClientCounterView } from '../components/ClientCounterView';
 import { COUNTER_QUERY_CLIENT, ADD_COUNTER_CLIENT } from '@gqlapp/counter-common';
@@ -10,38 +10,30 @@ interface ButtonProps {
   t: TranslateFunction;
 }
 
-const IncreaseButton = ({ counterAmount, t }: ButtonProps): any => (
-  <Mutation mutation={ADD_COUNTER_CLIENT}>
-    {(mutate: MutationFn) => {
-      const addClientCounter = (amount: any) => () => {
-        const { value }: any = mutate({ variables: { amount } });
-        return value;
-      };
+const IncreaseButton = ({ counterAmount, t }: ButtonProps) => {
+  const addClientCounter = useMutation(ADD_COUNTER_CLIENT, {
+    variables: { amount: counterAmount }
+  });
 
-      const onClickHandler = () => addClientCounter(counterAmount);
-      return <ClientCounterButton text={t('btnLabel')} onClick={onClickHandler()} />;
-    }}
-  </Mutation>
-);
+  return <ClientCounterButton text={t('btnLabel')} onClick={addClientCounter} />;
+};
 
 interface CounterProps {
   t: TranslateFunction;
 }
 
-const ClientCounter = ({ t }: CounterProps) => (
-  <Query query={COUNTER_QUERY_CLIENT}>
-    {({
-      data: {
-        clientCounter: { amount }
-      }
-    }: any) => {
-      return (
-        <ClientCounterView text={t('text', { amount })}>
-          <IncreaseButton t={t} counterAmount={1} />
-        </ClientCounterView>
-      );
-    }}
-  </Query>
-);
+const ClientCounter = ({ t }: CounterProps) => {
+  const {
+    data: {
+      clientCounter: { amount }
+    }
+  } = useQuery(COUNTER_QUERY_CLIENT);
+
+  return (
+    <ClientCounterView text={t('text', { amount })}>
+      <IncreaseButton t={t} counterAmount={1} />
+    </ClientCounterView>
+  );
+};
 
 export default translate('clientCounter')(ClientCounter);

--- a/modules/counter/client-react/serverCounter/containers/ServerCounter.tsx
+++ b/modules/counter/client-react/serverCounter/containers/ServerCounter.tsx
@@ -39,13 +39,7 @@ const IncreaseButton = ({ counterAmount, t, counter }: ButtonProps) => {
   return <ServerCounterButton text={t('btnLabel')} onClick={addServerCounter} />;
 };
 
-interface CounterProps {
-  t: TranslateFunction;
-  loading: boolean;
-  counter: any;
-}
-
-const ServerCounter = ({ t, counter, loading }: CounterProps) => {
+const subscribeOnCounterUpdate = () =>
   useSubscription(COUNTER_SUBSCRIPTION, {
     onSubscriptionData: ({ client, subscriptionData: { data } }) => {
       const newAmount = data.counterUpdated.amount;
@@ -61,6 +55,15 @@ const ServerCounter = ({ t, counter, loading }: CounterProps) => {
       });
     }
   });
+
+interface CounterProps {
+  t: TranslateFunction;
+  loading: boolean;
+  counter: any;
+}
+
+const ServerCounter = ({ t, counter, loading }: CounterProps) => {
+  subscribeOnCounterUpdate();
 
   return (
     <ServerCounterView t={t} counter={counter} loading={loading}>

--- a/modules/counter/client-react/serverCounter/containers/ServerCounter.tsx
+++ b/modules/counter/client-react/serverCounter/containers/ServerCounter.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+// import React from 'react';
+import React, { useEffect } from 'react';
 import { Mutation, Query } from 'react-apollo';
 import update from 'immutability-helper';
 
@@ -54,73 +55,41 @@ interface CounterProps {
   counter: any;
 }
 
-class ServerCounter extends React.Component<CounterProps> {
-  private subscription: any;
-
-  constructor(props: CounterProps) {
-    super(props);
-    this.subscription = null;
-  }
-
-  public componentDidMount() {
-    if (!this.props.loading) {
-      // Subscribe or re-subscribe
-      if (!this.subscription) {
-        this.subscribeToCount();
-      }
-    }
-  }
-
-  // remove when Renderer is overwritten
-  public componentDidUpdate(prevProps: CounterProps) {
-    if (!prevProps.loading) {
-      // Subscribe or re-subscribe
-      if (!this.subscription) {
-        this.subscribeToCount();
-      }
-    }
-  }
-
-  public componentWillUnmount() {
-    if (this.subscription) {
-      this.subscription();
-    }
-  }
-
-  public subscribeToCount() {
-    this.subscription = this.props.subscribeToMore({
-      document: COUNTER_SUBSCRIPTION,
-      variables: {},
-      updateQuery: (
-        prev: any,
-        {
-          subscriptionData: {
-            data: {
-              counterUpdated: { amount }
-            }
+const subscribeToCounter = (subscribeToMore: (opts: any) => any) =>
+  subscribeToMore({
+    document: COUNTER_SUBSCRIPTION,
+    variables: {},
+    updateQuery: (
+      prev: any,
+      {
+        subscriptionData: {
+          data: {
+            counterUpdated: { amount }
           }
-        }: any
-      ) => {
-        return update(prev, {
-          serverCounter: {
-            amount: {
-              $set: amount
-            }
+        }
+      }: any
+    ) => {
+      return update(prev, {
+        serverCounter: {
+          amount: {
+            $set: amount
           }
-        });
-      }
-    });
-  }
+        }
+      });
+    }
+  });
 
-  public render() {
-    const { t, counter, loading } = this.props;
-    return (
-      <ServerCounterView t={t} counter={counter} loading={loading}>
-        <IncreaseButton t={t} counterAmount={1} counter={counter} />
-      </ServerCounterView>
-    );
-  }
-}
+const ServerCounter = ({ t, counter, loading, subscribeToMore }: CounterProps) => {
+  useEffect(() => {
+    const subscribe = subscribeToCounter(subscribeToMore);
+    return () => subscribe();
+  });
+  return (
+    <ServerCounterView t={t} counter={counter} loading={loading}>
+      <IncreaseButton t={t} counterAmount={1} counter={counter} />
+    </ServerCounterView>
+  );
+};
 
 const ServerCounterWithQuery = (props: any) => (
   <Query query={COUNTER_QUERY}>

--- a/modules/testing/client-react/Renderer.tsx
+++ b/modules/testing/client-react/Renderer.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import { ApolloProvider } from 'react-apollo';
+import { ApolloProvider as ApolloHooksProvider } from 'react-apollo-hooks';
 import { ApolloLink, Observable, Operation } from 'apollo-link';
 import { addTypenameToDocument } from 'apollo-utilities';
 import { Router, Switch } from 'react-router-dom';
@@ -177,7 +178,9 @@ export class Renderer {
   public withApollo(component: ReactElement<any>) {
     return ref.clientModules.getWrappedRoot(
       <Provider store={this.store}>
-        <ApolloProvider client={this.client}>{component}</ApolloProvider>
+        <ApolloProvider client={this.client}>
+          <ApolloHooksProvider client={this.client}>{component}</ApolloHooksProvider>
+        </ApolloProvider>
       </Provider>
     );
   }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -84,6 +84,7 @@
     "prop-types": "^15.6.0",
     "react": "^16.8.0",
     "react-apollo": "^2.5.5",
+    "react-apollo-hooks": "^0.4.5",
     "react-art": "^16.8.0",
     "react-cookie": "^2.2.0",
     "react-debounce-input": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3052,10 +3052,10 @@ ansi@^0.3.0, ansi@~0.3.1:
   resolved "https://registry.yarnpkg.com/ansi/-/ansi-0.3.1.tgz#0c42d4fb17160d5a9af1e484bace1c66922c1b21"
   integrity sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=
 
-ant-design-palettes@^1.1.3, "ant-design-palettes@npm:@ant-design/colors":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@ant-design/colors/-/colors-3.0.1.tgz#4bedd9faf73a8eda734a3e74f1476707282f6ec2"
-  integrity sha512-VmFxjS185QZLnPfOyUdAC+DGgEeQakSAs2bY3zPb3TZyLGLCGwxjtyTz6ZF8+3WpZIKy/F7+lR5via92NnpU4A==
+ant-design-palettes@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/ant-design-palettes/-/ant-design-palettes-1.1.3.tgz#84119b1a4d86363adc52a38d587e65336a0a27dd"
+  integrity sha512-UpkkTp8egEN21KZNvY7sTcabLlkHvLvS71EVPk4CYi77Z9AaGGCaVn7i72tbOgWDrQp2wjIg8WgMbKBdK7GtWA==
   dependencies:
     tinycolor2 "^1.4.1"
 
@@ -6335,6 +6335,11 @@ core-js@3.0.1, core-js@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -8571,11 +8576,6 @@ fbemitter@^2.1.1:
   dependencies:
     fbjs "^0.8.4"
 
-fbjs-css-vars@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
-  integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
-
 fbjs-scripts@^0.8.1:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/fbjs-scripts/-/fbjs-scripts-0.8.3.tgz#b854de7a11e62a37f72dab9aaf4d9b53c4a03174"
@@ -8592,13 +8592,12 @@ fbjs-scripts@^0.8.1:
     semver "^5.1.0"
     through2 "^2.0.0"
 
-fbjs@0.8.17, fbjs@^0.8.0, fbjs@^0.8.15, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9, fbjs@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-1.0.0.tgz#52c215e0883a3c86af2a7a776ed51525ae8e0a5a"
-  integrity sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==
+fbjs@0.8.17, fbjs@^0.8.0, fbjs@^0.8.15, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
   dependencies:
-    core-js "^2.4.1"
-    fbjs-css-vars "^1.0.0"
+    core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
     loose-envify "^1.0.0"
     object-assign "^4.1.0"
@@ -9542,7 +9541,7 @@ graphql-upload@^8.0.2:
     http-errors "^1.7.2"
     object-path "^0.11.4"
 
-graphql@14.1.1, graphql@^14.1.1:
+graphql@^14.1.1:
   version "14.1.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.1.1.tgz#d5d77df4b19ef41538d7215d1e7a28834619fac0"
   integrity sha512-C5zDzLqvfPAgTtP8AUPIt9keDabrdRAqSWjj2OPRKrKxI9Fb65I36s1uCs1UUBFnSWTdO7hyHi7z1ZbwKMKF6Q==
@@ -10175,7 +10174,7 @@ immediate@~3.0.5:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
-immutability-helper@2.8.1, immutability-helper@^2.6.2:
+immutability-helper@^2.6.2:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.8.1.tgz#3c5ec05fcd83676bfae7146f319595243ad904f4"
   integrity sha512-8AVB5EUpRBUdXqfe4cFsFECsOIZ9hX/Arl8B8S9/tmwpYv3UWvOsXUPOjkuZIMaVxfSWkxCzkng1rjmEoSWrxQ==
@@ -11748,10 +11747,10 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
-kleur@^2.0.1, kleur@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
-  integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+kleur@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-2.0.2.tgz#b704f4944d95e255d038f0cb05fb8a602c55a300"
+  integrity sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ==
 
 knex@^0.14.2:
   version "0.14.6"
@@ -16101,6 +16100,13 @@ react-addons-test-utils@^16.0.0-alpha.3:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
+react-apollo-hooks@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/react-apollo-hooks/-/react-apollo-hooks-0.4.5.tgz#7fe6a8ddfdc92df2da664d399ea77a0da4a10bad"
+  integrity sha512-fq04h88hg4ONtlzxYInmv7Okqqstzk3UCp55jHWOlIO2lFKoZPhQrtCz7A+TrcRu8GGwtG1SsioRKN8kIQaAOQ==
+  dependencies:
+    lodash "^4.17.11"
+
 react-apollo@^2.3.1, react-apollo@^2.5.5:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.5.tgz#0f27079a8fa9d9ceea8b29a5977eb42885f88fb9"
@@ -16517,7 +16523,6 @@ react-native-view-shot@2.5.0:
 
 "react-native@https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz":
   version "0.57.1"
-  uid "78bcdc7d34a2f4a58c179699e775842a74da6c6f"
   resolved "https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz#78bcdc7d34a2f4a58c179699e775842a74da6c6f"
   dependencies:
     absolute-path "^0.0.0"
@@ -19515,7 +19520,7 @@ unzip-response@^2.0.1:
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
   integrity sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=
 
-upath@^1.1.0, upath@^1.1.1:
+upath@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
   integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
@@ -19895,7 +19900,7 @@ watch@~0.18.0:
     exec-sh "^0.2.0"
     minimist "^1.2.0"
 
-watchpack@^1.5.0, "watchpack@https://github.com/Globegitter/watchpack":
+watchpack@^1.5.0:
   version "1.6.0"
   resolved "https://github.com/Globegitter/watchpack#d903e64a910ab068299f824b04a5e216a15672e9"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3052,10 +3052,10 @@ ansi@^0.3.0, ansi@~0.3.1:
   resolved "https://registry.yarnpkg.com/ansi/-/ansi-0.3.1.tgz#0c42d4fb17160d5a9af1e484bace1c66922c1b21"
   integrity sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=
 
-ant-design-palettes@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/ant-design-palettes/-/ant-design-palettes-1.1.3.tgz#84119b1a4d86363adc52a38d587e65336a0a27dd"
-  integrity sha512-UpkkTp8egEN21KZNvY7sTcabLlkHvLvS71EVPk4CYi77Z9AaGGCaVn7i72tbOgWDrQp2wjIg8WgMbKBdK7GtWA==
+ant-design-palettes@^1.1.3, "ant-design-palettes@npm:@ant-design/colors":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@ant-design/colors/-/colors-3.0.1.tgz#4bedd9faf73a8eda734a3e74f1476707282f6ec2"
+  integrity sha512-VmFxjS185QZLnPfOyUdAC+DGgEeQakSAs2bY3zPb3TZyLGLCGwxjtyTz6ZF8+3WpZIKy/F7+lR5via92NnpU4A==
   dependencies:
     tinycolor2 "^1.4.1"
 
@@ -6335,11 +6335,6 @@ core-js@3.0.1, core-js@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
-
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -8576,6 +8571,11 @@ fbemitter@^2.1.1:
   dependencies:
     fbjs "^0.8.4"
 
+fbjs-css-vars@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
+  integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
+
 fbjs-scripts@^0.8.1:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/fbjs-scripts/-/fbjs-scripts-0.8.3.tgz#b854de7a11e62a37f72dab9aaf4d9b53c4a03174"
@@ -8592,12 +8592,13 @@ fbjs-scripts@^0.8.1:
     semver "^5.1.0"
     through2 "^2.0.0"
 
-fbjs@0.8.17, fbjs@^0.8.0, fbjs@^0.8.15, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
-  version "0.8.17"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
-  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
+fbjs@0.8.17, fbjs@^0.8.0, fbjs@^0.8.15, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9, fbjs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-1.0.0.tgz#52c215e0883a3c86af2a7a776ed51525ae8e0a5a"
+  integrity sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==
   dependencies:
-    core-js "^1.0.0"
+    core-js "^2.4.1"
+    fbjs-css-vars "^1.0.0"
     isomorphic-fetch "^2.1.1"
     loose-envify "^1.0.0"
     object-assign "^4.1.0"
@@ -9541,7 +9542,7 @@ graphql-upload@^8.0.2:
     http-errors "^1.7.2"
     object-path "^0.11.4"
 
-graphql@^14.1.1:
+graphql@14.1.1, graphql@^14.1.1:
   version "14.1.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.1.1.tgz#d5d77df4b19ef41538d7215d1e7a28834619fac0"
   integrity sha512-C5zDzLqvfPAgTtP8AUPIt9keDabrdRAqSWjj2OPRKrKxI9Fb65I36s1uCs1UUBFnSWTdO7hyHi7z1ZbwKMKF6Q==
@@ -10174,7 +10175,7 @@ immediate@~3.0.5:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
-immutability-helper@^2.6.2:
+immutability-helper@2.8.1, immutability-helper@^2.6.2:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.8.1.tgz#3c5ec05fcd83676bfae7146f319595243ad904f4"
   integrity sha512-8AVB5EUpRBUdXqfe4cFsFECsOIZ9hX/Arl8B8S9/tmwpYv3UWvOsXUPOjkuZIMaVxfSWkxCzkng1rjmEoSWrxQ==
@@ -11747,10 +11748,10 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
-kleur@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/kleur/-/kleur-2.0.2.tgz#b704f4944d95e255d038f0cb05fb8a602c55a300"
-  integrity sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ==
+kleur@^2.0.1, kleur@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
+  integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
 knex@^0.14.2:
   version "0.14.6"
@@ -19520,7 +19521,7 @@ unzip-response@^2.0.1:
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
   integrity sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=
 
-upath@^1.1.1:
+upath@^1.1.0, upath@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
   integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
@@ -19900,7 +19901,7 @@ watch@~0.18.0:
     exec-sh "^0.2.0"
     minimist "^1.2.0"
 
-watchpack@^1.5.0:
+watchpack@^1.5.0, "watchpack@https://github.com/Globegitter/watchpack":
   version "1.6.0"
   resolved "https://github.com/Globegitter/watchpack#d903e64a910ab068299f824b04a5e216a15672e9"
   dependencies:


### PR DESCRIPTION
Integrate `react-apollo-hooks` into the kit, to allow the use of Apollo Hooks.