### PR TITLE
Compile Node backend for node target

### DIFF
--- a/modules/reports/client-react/pdf/client/containers/PrintReport.tsx
+++ b/modules/reports/client-react/pdf/client/containers/PrintReport.tsx
@@ -25,7 +25,7 @@ const Report = ({ t }: ReportProps) => {
 
   return (
     <Query query={ReportQuery}>
-      {({ loading, data }) => {
+      {({ loading, data }: any) => {
         if (loading) {
           return t('loading');
         }

--- a/modules/testing/server-ts/integrationSetup.ts
+++ b/modules/testing/server-ts/integrationSetup.ts
@@ -15,11 +15,8 @@ let server: Server;
 let apollo: ApolloClient<any>;
 
 before(async () => {
-  if (!global._babelPolyfill) {
-    // tslint:disable-next-line
-    require('@babel/register')({ cwd: __dirname + '/../../..', extensions: ['.js', '.ts'], ignore: [ /build\/main.js/ ] });
-    require('@babel/polyfill');
-  }
+  // tslint:disable-next-line
+  require('@babel/register')({ cwd: __dirname + '/../../..', extensions: ['.js', '.ts'], ignore: [ /build\/main.js/ ] });
   await populateTestDb();
 
   server = await serverPromise;

--- a/packages/client-angular/package.json
+++ b/packages/client-angular/package.json
@@ -3,10 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "src",
-  "engines": {
-    "node": ">= 6.11.1 <= 10",
-    "yarn": ">= 1.0.0"
-  },
   "scripts": {
     "build": "cross-env NODE_ENV=production zen build",
     "clean": "rimraf build .tmp",

--- a/packages/client-vue/package.json
+++ b/packages/client-vue/package.json
@@ -3,10 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "src",
-  "engines": {
-    "node": ">= 6.11.1 <= 10",
-    "yarn": ">= 1.0.0"
-  },
   "scripts": {
     "build": "cross-env NODE_ENV=production zen build",
     "clean": "rimraf build .tmp",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,10 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "src",
-  "engines": {
-    "node": ">= 6.11.1 <= 10",
-    "yarn": ">= 1.0.0"
-  },
   "scripts": {
     "build": "cross-env NODE_ENV=production zen build",
     "clean": "rimraf build .tmp",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -3,10 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "src",
-  "engines": {
-    "node": ">= 6.11.1 <= 10",
-    "yarn": ">= 1.0.0"
-  },
   "scripts": {
     "build": "cross-env NODE_ENV=production zen build",
     "clean": "rimraf build .expo .tmp",

--- a/packages/server/.zenrc.js
+++ b/packages/server/.zenrc.js
@@ -16,7 +16,9 @@ const config = {
   },
   options: {
     cache: '../../.cache',
+    tsLoaderConfig: { transpileOnly: false, configFile: 'tsconfig.node.json' },
     ssr: true,
+    minify: false,
     defines: {
       __DEV__: process.env.NODE_ENV !== 'production',
       __SERVER_PORT__: 8080,

--- a/packages/server/babel.config.js
+++ b/packages/server/babel.config.js
@@ -2,7 +2,12 @@ module.exports = {
   compact: false,
   presets: ['@babel/preset-react', ['@babel/preset-env', { targets: { node: true }, modules: false }]],
   plugins: [
+    '@babel/plugin-transform-destructuring',
+    '@babel/plugin-transform-regenerator',
+    '@babel/plugin-transform-runtime',
+    ['@babel/plugin-proposal-decorators', { legacy: true }],
     '@babel/plugin-proposal-class-properties',
+    '@babel/plugin-proposal-object-rest-spread',
     ['styled-components', { ssr: true }],
     ['import', { libraryName: 'antd-mobile' }]
   ],

--- a/packages/server/babel.config.js
+++ b/packages/server/babel.config.js
@@ -1,13 +1,8 @@
 module.exports = {
   compact: false,
-  presets: ['@babel/preset-react', ['@babel/preset-env', { modules: false }]],
+  presets: ['@babel/preset-react', ['@babel/preset-env', { targets: { node: true }, modules: false }]],
   plugins: [
-    '@babel/plugin-transform-destructuring',
-    '@babel/plugin-transform-regenerator',
-    '@babel/plugin-transform-runtime',
-    ['@babel/plugin-proposal-decorators', { legacy: true }],
     '@babel/plugin-proposal-class-properties',
-    '@babel/plugin-proposal-object-rest-spread',
     ['styled-components', { ssr: true }],
     ['import', { libraryName: 'antd-mobile' }]
   ],

--- a/packages/server/knexfile.js
+++ b/packages/server/knexfile.js
@@ -1,5 +1,4 @@
 require('dotenv/config');
 require('@babel/register')({ cwd: __dirname + '/../..', extensions: ['.js', '.ts'] });
-require('@babel/polyfill');
 
 module.exports = require('@gqlapp/database-server-ts/knexdata');

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,8 +4,7 @@
   "version": "1.0.0",
   "main": "src",
   "engines": {
-    "node": ">= 6.11.1 <= 10",
-    "yarn": ">= 1.0.0"
+    "node": ">= 8 <= 10"
   },
   "scripts": {
     "build": "cross-env NODE_ENV=production zen build",

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "include": [
-    "../../**/typings.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ]
-}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,8 +1,9 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "target": "es2017",
     "module": "es2017",
-    "lib": ["es2015", "dom", "es2017"]
+    "lib": ["es2015", "dom", "esnext"]
   },
   "include": [
     "**/typings.d.ts",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "es2017",
+    "lib": ["es2015", "dom", "es2017"]
+  },
+  "include": [
+    "**/typings.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.vue"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16517,6 +16517,7 @@ react-native-view-shot@2.5.0:
 
 "react-native@https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz":
   version "0.57.1"
+  uid "78bcdc7d34a2f4a58c179699e775842a74da6c6f"
   resolved "https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz#78bcdc7d34a2f4a58c179699e775842a74da6c6f"
   dependencies:
     absolute-path "^0.0.0"


### PR DESCRIPTION
This PR change Babel and TypeScript options to target Node environment. This should use native Node features which should result in less CPU load