### PR TITLE
make mobile app send API request with locale parameter

### DIFF
--- a/modules/core/common/createApolloClient.ts
+++ b/modules/core/common/createApolloClient.ts
@@ -12,10 +12,12 @@ import ApolloCacheRouter from 'apollo-cache-router';
 import { hasDirectives } from 'apollo-utilities';
 import { DocumentNode } from 'graphql';
 import { IResolvers } from 'graphql-tools';
+import i18n from 'i18next';
 
 import settings from '@gqlapp/config';
 
 import log from './log';
+import { PLATFORM } from '../../../packages/common/utils';
 
 interface CreateApolloClientOptions {
   apiUrl?: string;
@@ -61,7 +63,7 @@ const createApolloClient = ({
   const queryLink = createNetLink
     ? createNetLink(apiUrl, getApolloClient)
     : new BatchHttpLink({
-        uri: apiUrl,
+        uri: settings.i18n.enabled && PLATFORM === 'mobile' ? () => `${apiUrl}?lng=${i18n.language}` : apiUrl,
         credentials: 'include',
         fetch
       });

--- a/modules/i18n/server-ts/index.ts
+++ b/modules/i18n/server-ts/index.ts
@@ -9,7 +9,8 @@ import settings from '@gqlapp/config';
 const beforeware = (app: Express) => {
   if (settings.i18n.enabled) {
     app.use((req: any, res, next) => {
-      const lang = req.universalCookies.get(settings.i18n.cookie) || req.acceptsLanguages(settings.i18n.langList);
+      const lang =
+        req.query.lng || req.universalCookies.get(settings.i18n.cookie) || req.acceptsLanguages(settings.i18n.langList);
       req.universalCookies.set(settings.i18n.cookie, lang);
       req.lng = lang;
       next();

--- a/modules/upload/client-react/netLink.js
+++ b/modules/upload/client-react/netLink.js
@@ -3,13 +3,18 @@ import { ApolloLink } from 'apollo-link';
 import { createUploadLink } from 'apollo-upload-client';
 import extractFiles from 'extract-files';
 import { cloneDeep } from 'lodash';
+import i18n from 'i18next';
+
+import settings from '@gqlapp/config';
+
+import { PLATFORM } from '../../../packages/common/utils';
 
 export default uri =>
   ApolloLink.split(
     ({ variables }) => extractFiles(cloneDeep(variables)).length > 0,
     createUploadLink({ uri, credentials: 'include' }),
     new BatchHttpLink({
-      uri,
+      uri: settings.i18n.enabled && PLATFORM === 'mobile' ? () => `${uri}?lng=${i18n.language}` : uri,
       credentials: 'include'
     })
   );


### PR DESCRIPTION
A further fix following up with [the last commit](https://github.com/sysgears/apollo-universal-starter-kit/commit/274ef8200a76d588a97f54fe20dfd672f732d9bd).

Problem:
Web client can send locale information to server through cookie, but mobile app can't. Although locale information is stored in Expo SecureStore in [LanguageDetector.native.ts](https://github.com/sysgears/apollo-universal-starter-kit/blob/master/modules/i18n/common-react/LanguageDetector.native.ts), API requests sent by mobile app won't include this locale information.

There is a way to manipulate cookies in mobile app, namely [react-native-cookies](https://github.com/joeferraro/react-native-cookies), but it's a native package and requires ejecting from Expo.

My solution is passing locale information as query string in API requests.

Before fix:
<img width="331" alt="Screen Shot 2019-05-15 at 8 53 08 PM" src="https://user-images.githubusercontent.com/229229/57766887-47fd7400-775c-11e9-919e-eeb47154217b.png">

After fix:
<img width="333" alt="Screen Shot 2019-05-15 at 9 00 56 PM" src="https://user-images.githubusercontent.com/229229/57766898-4df35500-775c-11e9-9107-fd2b8277d68a.png">

I'm only suggesting one possible solution, not very neat, nor very modular (coupling i18n module with core module). You can merge this PR or choose to fix this problem in some other way.








