### PR TITLE
Fix missing translations in IOS.

### DIFF
--- a/modules/look/client-react-native/ui-native-base/components/LanguagePicker.jsx
+++ b/modules/look/client-react-native/ui-native-base/components/LanguagePicker.jsx
@@ -49,6 +49,8 @@ export default class LanguagePicker extends React.Component {
           </Text>
           {Platform.OS === 'ios' && (
             <SimplePicker
+              confirmText={i18n.t('i18n:btnConfirm')}
+              cancelText={i18n.t('i18n:btnCancel')}
               ref={el => (this.pickerRef = el)}
               options={langs.map(lang => lang.slice(0, 2).toUpperCase())}
               onSubmit={lang => this.changeLang(langs.filter(lng => lng.indexOf(lang) > -1)[0] || lang)}


### PR DESCRIPTION
In side bar after clicking "change language" the "cancel" and "confirm" buttons are missing translations.
Before:

<img width="418" alt="Screenshot 2019-05-18 at 02 47 25" src="https://user-images.githubusercontent.com/4124323/57957907-69568f80-7917-11e9-9b5c-7994968f00b3.png">

After:

<img width="418" alt="Screenshot 2019-05-18 at 02 40 38" src="https://user-images.githubusercontent.com/4124323/57957918-74a9bb00-7917-11e9-8d8d-5975e9b729f9.png">
