### PR TITLE
Support custom namespaces for modules

### DIFF
--- a/docs/Importing Modules.md
+++ b/docs/Importing Modules.md
@@ -45,3 +45,24 @@ can use it by importing necessary classes or components with ES6 `import`.
 
 [yarn documentation]: https://yarnpkg.com/lang/en/docs/workspaces/
 [webpack dependency management]: https://webpack.js.org/guides/dependency-management/
+
+## Modules with custom namespaces
+
+Within your module's `package.json`,
+you can change the namespace from `@gqlapp` to something like:
+
+```json
+{
+  "name": "@my-namespace/my-module-server-ts",
+  "version": "0.1.0",
+  "private": true
+}
+```
+
+To use a custom npm namespace
+
+1. Change the namespace in the `package.json` file
+2. Run ApolloKit like: `MODULENAME_REGEX="(@my-namespace|@gqlapp|client|webpack\/hot\/poll)" yarn watch`
+
+`(@gqlapp|client|webpack\/hot\/poll)` is the default.
+

--- a/packages/server/webpack.config.js
+++ b/packages/server/webpack.config.js
@@ -9,8 +9,8 @@ const WebpackShellPlugin = require('webpack-shell-plugin');
 
 const buildConfig = require('./build.config');
 
-const whitelistExtra = process.env.NPM_WHITELIST ? `${process.env.NPM_WHITELIST}|` : "";
-const whitelistRegex = new RegExp(`(${whitelistExtra}@gqlapp|client|webpack\/hot\/poll)`);
+const modulenameRegexValue = process.env.MODULENAME_REGEX ? `${process.env.MODULENAME_REGEX}` : "(@gqlapp|client|webpack\/hot\/poll)";
+const modulenameRegex = new RegExp(`${modulenameRegexValue}`);
 
 const config = {
   entry: {
@@ -129,7 +129,7 @@ const config = {
     nodeExternals(),
     nodeExternals({
       modulesDir: path.resolve(__dirname, '../../node_modules'),
-      whitelist: [whitelistRegex]
+      whitelist: [modulenameRegex]
     })
   ],
   node: { __dirname: true, __filename: true },

--- a/packages/server/webpack.config.js
+++ b/packages/server/webpack.config.js
@@ -9,6 +9,9 @@ const WebpackShellPlugin = require('webpack-shell-plugin');
 
 const buildConfig = require('./build.config');
 
+const whitelistExtra = process.env.NPM_WHITELIST ? `${process.env.NPM_WHITELIST}|` : "";
+const whitelistRegex = new RegExp(`(${whitelistExtra}@gqlapp|client|webpack\/hot\/poll)`);
+
 const config = {
   entry: {
     index: (process.env.NODE_ENV !== 'production' ? ['webpack/hot/poll?200'] : []).concat([
@@ -126,7 +129,7 @@ const config = {
     nodeExternals(),
     nodeExternals({
       modulesDir: path.resolve(__dirname, '../../node_modules'),
-      whitelist: [/(@gqlapp|client|webpack\/hot\/poll)/]
+      whitelist: [whitelistRegex]
     })
   ],
   node: { __dirname: true, __filename: true },


### PR DESCRIPTION
add support for custom npm namespace in server, it crashes unless you get your own into that regex

where else might this be an issue?

- `packages/client/webpack.config.js` there is a node_modules exclude thing in there that has the `@gqlapp`

basically anywhere `@gqlapp` shows up, we would want to add support for adding in the `NPM_WHITELIST` env var I used in the first commit.

btw, is there another name you would prefer for that ENV_VAR @vlasenko ?
- NPM_NAMESPACES ?