### PR TITLE
Extract-files breaking changes

### DIFF
--- a/modules/upload/client-react/netLink.js
+++ b/modules/upload/client-react/netLink.js
@@ -2,11 +2,10 @@ import { BatchHttpLink } from 'apollo-link-batch-http';
 import { ApolloLink } from 'apollo-link';
 import { createUploadLink } from 'apollo-upload-client';
 import { extractFiles } from 'extract-files';
-import { cloneDeep } from 'lodash';
 
 export default uri =>
   ApolloLink.split(
-    ({ variables }) => extractFiles(cloneDeep(variables)).length > 0,
+    ({ variables }) => extractFiles(variables).files.size > 0,
     createUploadLink({ uri, credentials: 'include' }),
     new BatchHttpLink({
       uri,


### PR DESCRIPTION
Now Extract-files handles the cloning and returns an object `{clone: <clone of your variables>, files: Map }` that contains the files.