### PR TITLE
Fix the broken link to FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Modules
 * [Gitter channel] &ndash; ask questions, find answers, and participate in general discussions
 * [GitHub issues] &ndash; submit issues and send feature requests
 * [Wiki] &ndash; read documentation for the usage scenarios of the starter kit; edit the documentation
-* [FAQ] &ndash; consult the Frequently Asked Questions section in Wiki
+* [FAQ] &ndash; consult the Frequently Asked Questions section
 
 ### Commercial Support
 
@@ -373,6 +373,7 @@ Copyright &copy; 2016-2019 [SysGears (Cyprus) Limited]. This source code is lice
 [mobile chat]: /docs/modules/Mobile%20Chat.md
 [project structure]: /docs/Project%20Structure.md
 [importing modules]: /docs/Importing%20Modules.md
+[frequently asked questions]: https://github.com/sysgears/apollo-universal-starter-kit/blob/master/docs/FAQ.md
 [sysgears (cyprus) limited]: http://sysgears.com
 [gitter channel]: https://gitter.im/sysgears/apollo-fullstack-starter-kit
 [github issues]: https://github.com/sysgears/apollo-universal-starter-kit/issues


### PR DESCRIPTION
Fixed the broken link to FAQ in the Apollo Universal Starter Kit Documentation section.