### PR TITLE
Utilize node-hmr-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "less-loader": "^4.1.0",
     "lint-staged": "^7.1.2",
     "mini-css-extract-plugin": "^0.4.1",
+    "node-hmr-plugin": "^1.0.1",
     "node-sass": "^4.7.2",
     "openurl": "^1.1.1",
     "postcss-loader": "^3.0.0",
@@ -176,7 +177,6 @@
     "webpack-manifest-plugin": "^2.0.3",
     "webpack-merge": "^4.1.4",
     "webpack-node-externals": "^1.7.2",
-    "webpack-shell-plugin": "^0.5.0",
     "webpack-sources": "^1.1.0",
     "webpack-virtual-modules": "^0.1.10",
     "whatwg-fetch": "^2.0.4"

--- a/packages/server/webpack.config.js
+++ b/packages/server/webpack.config.js
@@ -5,7 +5,7 @@ const path = require('path');
 const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const nodeExternals = require('webpack-node-externals');
-const WebpackShellPlugin = require('webpack-shell-plugin');
+const NodeHmrPlugin = require('node-hmr-plugin');
 
 const buildConfig = require('./build.config');
 
@@ -105,12 +105,7 @@ const config = {
   mode: process.env.NODE_ENV || 'development',
   performance: { hints: false },
   plugins: (process.env.NODE_ENV !== 'production'
-    ? [
-        new webpack.HotModuleReplacementPlugin(),
-        new WebpackShellPlugin({
-          onBuildEnd: ['nodemon build --watch false']
-        })
-      ]
+    ? [new webpack.HotModuleReplacementPlugin(), new NodeHmrPlugin({ cmd: '{app}', restartOnExitCodes: [250] })]
     : []
   ).concat([
     new CleanWebpackPlugin('build'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -16454,6 +16454,13 @@ node-gyp@^4.0.0:
     tar "^4.4.8"
     which "1"
 
+node-hmr-plugin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/node-hmr-plugin/-/node-hmr-plugin-1.0.1.tgz#a2dfd84741d1c9a18fa81391693c6b040794389a"
+  integrity sha512-i9yePOZjhaqOxpgUx/386EoN/arPDGMRqiR3Q2Mj4vJxQDm6oF+drw+Bs4TozJkCO9iTDvLWSQZH8oTIqcMn4g==
+  dependencies:
+    webpack-log "^2.0.0"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -24394,11 +24401,6 @@ webpack-node-externals@^1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"
   integrity sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==
-
-webpack-shell-plugin@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/webpack-shell-plugin/-/webpack-shell-plugin-0.5.0.tgz#29b8a1d80ddeae0ddb10e729667f728653c2c742"
-  integrity sha1-Kbih2A3erg3bEOcpZn9yhlPCx0I=
 
 webpack-sources@^1.0.1, webpack-sources@^1.0.2, webpack-sources@^1.1.0, webpack-sources@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
This PR will utilize `node-hmr-plugin`, a Webpack plugin specifically crafted to run and restart `node` process during Node app development with Webpack and HMR