### PR TITLE
Read field meta data for nested form data, too

### DIFF
--- a/modules/forms/client-react/FieldAdapter.jsx
+++ b/modules/forms/client-react/FieldAdapter.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'formik';
+import { get as getPath } from 'lodash';
 
 import { PLATFORM } from '@gqlapp/core-common';
 
@@ -63,8 +64,8 @@ class FieldAdapter extends Component {
     value = value || '';
     checked = checked || false;
     const meta = {
-      touched: formik.touched[name],
-      error: formik.errors[name]
+      touched: getPath(formik.touched, name),
+      error: getPath(formik.errors, name)
     };
 
     const input = {


### PR DESCRIPTION
Enables FieldAdapter to determine touched and error state not only for the top level form object, but for nested fields, too.

Imagine a Post with some attached files created in the same form.  
That could create a form values object like `{title: 'foo', files: [{filename: 'bar.txt'}]`

Whilst formik.touched['title'] works good, formik.touched['files[0].filename'] doesn't.  
Using the lodash get method, the nested path can be easily extracted from formiks meta objects, too.