### PR TITLE
Bug fix: The Pagination demo doesn't work and continuously reload 

### DIFF
--- a/modules/pagination/client-react/containers/DataProvider.jsx
+++ b/modules/pagination/client-react/containers/DataProvider.jsx
@@ -38,7 +38,7 @@ export const useDataProvider = () => {
 
   useEffect(() => {
     loadData(0, 'replace');
-  });
+  }, [loadData]);
 
   return { items, loadData };
 };

--- a/modules/pagination/client-react/containers/DataProvider.jsx
+++ b/modules/pagination/client-react/containers/DataProvider.jsx
@@ -35,10 +35,10 @@ export const useDataProvider = () => {
     },
     [items]
   );
-
-  useEffect(() => {
+  const useMountEffect = fn => useEffect(fn, []);
+  useMountEffect(() => {
     loadData(0, 'replace');
-  }, [loadData]);
+  });
 
   return { items, loadData };
 };


### PR DESCRIPTION
Bugfix: The Pagination demo doesn't work and continuously reload because the dependency array is missed in the useEffect hook of useDataProvider. 