### PR TITLE
Explicitly specify returning column when inserting a user

### DIFF
--- a/modules/user/server-ts/sql.js
+++ b/modules/user/server-ts/sql.js
@@ -138,7 +138,9 @@ class User {
   }
 
   register({ username, email, role = 'user', isActive }, passwordHash) {
-    return knex('user').insert(decamelizeKeys({ username, email, role, passwordHash, isActive }));
+    return knex('user')
+      .returning('id')
+      .insert(decamelizeKeys({ username, email, role, passwordHash, isActive }));
   }
 
   createFacebookAuth({ id, displayName, userId }) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

I ran into an exception when this line of code is executed:

https://github.com/sysgears/apollo-universal-starter-kit/blob/969cc51155d7be88f97e27f305bf678836fa9220/modules/user/server-ts/social/facebook/index.js#L23

Then I found out nothing was returned because my db happens to be postgresql, as stated in knexjs documents: 

```
// Returns [1] in "mysql", "sqlite", "oracle"; [] in "postgresql" unless the 'returning' parameter is set.
knex('books').insert({title: 'Slaughterhouse Five'})
```

...

**How did you fix it?**

Explicitly specify the returning column i.e. 'id' column with returning()

...
