### PR TITLE
add getIdentity/getHash to apollo server context

### DIFF
--- a/modules/user/server-ts/index.js
+++ b/modules/user/server-ts/index.js
@@ -25,7 +25,9 @@ const createContextFunc = ({ req }) => ({
   auth: {
     isAuthenticated: req && req.identity,
     scope: req && req.identity && req.identity.role ? scopes[req.identity.role] : null
-  }
+  },
+  getIdentity,
+  getHash
 });
 
 const appContext = {


### PR DESCRIPTION
**What's the problem this PR addresses?**

If getIdentity and getHash only exist in appContext but not in apollo server context, this line of exception could be triggered: https://github.com/sysgears/apollo-universal-starter-kit/blob/1181fdddc26641ac9cdb2a2b832417148f9eb602/modules/authentication/server-ts/access/jwt/resolvers.js#L27

To reproduce this bug:
1. disable session, only enable jwt
2. login to website
3. wait 1 minute (assume jwt token is configured to expire in "1m")
4. then on the website click to a route that requires login (such as posts)
5. you'll see the refreshToken request is sent and the above exception is triggered

...

**How did you fix it?**

add getIdentity/getHash to apollo server context

...
