### PR TITLE
Fix no session on social Logins

### DIFF
--- a/modules/user/server-ts/social/shared.js
+++ b/modules/user/server-ts/social/shared.js
@@ -1,4 +1,5 @@
 import { access } from '@gqlapp/authentication-server-ts';
+import bcrypt from 'bcryptjs';
 import User from '../sql';
 
 export async function onAuthenticationSuccess(req, res) {
@@ -14,10 +15,13 @@ export async function onAuthenticationSuccess(req, res) {
 }
 
 export const registerUser = async ({ id, username, displayName, emails: [{ value }] }) => {
+  const passwordHash = await bcrypt.hash(id || username || displayName, 12); 
   return User.register({
     username: username || displayName,
     email: value,
     password: id,
     isActive: true
-  });
+  },
+   passwordHash
+  );
 };


### PR DESCRIPTION
Because social tokens are constructed via await access.grantAccess(user, req, user.passwordHash), and password_hash was missing session could not be established.
