### PR TITLE
Fix no session on social logins

### DIFF
--- a/modules/authentication/server-ts/access/AccessModule.ts
+++ b/modules/authentication/server-ts/access/AccessModule.ts
@@ -14,10 +14,10 @@ class AccessModule extends ServerModule {
   }
 
   get grantAccess() {
-    return async (identity: any, req: Request, passwordHash: string) => {
+    return async (identity: any, req: Request, identityId: string) => {
       let result = {};
       for (const grant of this.grant) {
-        result = merge(result, await grant(identity, req, passwordHash));
+        result = merge(result, await grant(identity, req, identityId));
       }
       return result;
     };

--- a/modules/user/server-ts/password/resolvers.js
+++ b/modules/user/server-ts/password/resolvers.js
@@ -40,7 +40,7 @@ export default () => ({
       const user = await User.getUserByUsernameOrEmail(usernameOrEmail);
       const errors = await validateUserPassword(user, password, req.t);
       if (!isEmpty(errors)) throw new UserInputError('Failed valid user password', { errors });
-      const tokens = await access.grantAccess(user, req, user.passwordHash);
+      const tokens = await access.grantAccess(user, req, user.id);
       return { user, tokens };
     },
     async register(obj, { input }, { mailer, User, req }) {

--- a/modules/user/server-ts/social/shared.js
+++ b/modules/user/server-ts/social/shared.js
@@ -4,7 +4,7 @@ import User from '../sql';
 export async function onAuthenticationSuccess(req, res) {
   const user = await User.getUserWithPassword(req.user.id);
   const redirectUrl = req.query.state;
-  const tokens = await access.grantAccess(user, req, user.passwordHash);
+  const tokens = await access.grantAccess(user, req, user.id);
 
   if (redirectUrl) {
     res.redirect(redirectUrl + (tokens ? '?data=' + JSON.stringify({ tokens }) : ''));
@@ -13,11 +13,10 @@ export async function onAuthenticationSuccess(req, res) {
   }
 }
 
-export const registerUser = async ({ id, username, displayName, emails: [{ value }] }) => {
+export const registerUser = async ({ username, displayName, emails: [{ value }] }) => {
   return User.register({
     username: username || displayName,
     email: value,
-    password: id,
     isActive: true
   });
 };


### PR DESCRIPTION
**What's the problem this PR addresses?**

Fixes session absence on social logins

**How did you fix it?**

grantAccess used passwordHash as a part of a refresh secret key. Since passwordHash were not set by registerUser it was sometimes null, sometimes undefined and session was invalidated because of that. I'm using identityId instead of passwordHash, which should be unique and always defined.
