### PR TITLE
Make find command in README BSD/macOS compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ For Windows 10:
 the command below, you can remove all Scala server files:
 
 ```bash
-find -name server-scala | xargs rm -rf
+find . -name server-scala | xargs rm -rf
 ```
 
 If you don't need the ready-made modules, you can also remove them using the [custom CLI].


### PR DESCRIPTION
**What's the problem this PR addresses?**

The find command in the README does not work on BSDs / macOS.
...

**How did you fix it?**

Add a directory specification to the find command (.).

...
