### PR TITLE
fix subscription pages being inside head

### DIFF
--- a/modules/payments/client-react/stripe/subscription/containers/AddSubscription.tsx
+++ b/modules/payments/client-react/stripe/subscription/containers/AddSubscription.tsx
@@ -55,8 +55,10 @@ const AddSubscription = ({ t, history, navigation }: AddSubscriptionProps) => {
   };
 
   return (
-    <Helmet>
-      <script src="https://js.stripe.com/v3/" type="text/javascript" />
+    <>
+      <Helmet>
+        <script src="https://js.stripe.com/v3/" type="text/javascript" />
+      </Helmet>
       <Mutation
         mutation={ADD_SUBSCRIPTION}
         update={(cache: ApolloCache<any>, { data: { addStripeSubscription } }: any) => {
@@ -75,13 +77,13 @@ const AddSubscription = ({ t, history, navigation }: AddSubscriptionProps) => {
                   <AddSubscriptionView submitting={submitting} onSubmit={onSubmit(addSubscription)} t={t} />
                 </StripeProvider>
               ) : (
-                <AddSubscriptionView submitting={submitting} onSubmit={onSubmit(addSubscription)} t={t} />
-              )}
+                  <AddSubscriptionView submitting={submitting} onSubmit={onSubmit(addSubscription)} t={t} />
+                )}
             </Fragment>
           );
         }}
       </Mutation>
-    </Helmet>
+    </>
   );
 };
 

--- a/modules/payments/client-react/stripe/subscription/containers/Auth.tsx
+++ b/modules/payments/client-react/stripe/subscription/containers/Auth.tsx
@@ -27,8 +27,10 @@ const SubscriptionAuthRouter = ({
   // empty screen when stripe subscription info is loading
   // Important: You don't need to include page layout inside protected routes!
   return (
-    <Helmet>
-      <script src="https://js.stripe.com/v3/" type="text/javascript" />
+    <>
+      <Helmet>
+        <script src="https://js.stripe.com/v3/" type="text/javascript" />
+      </Helmet>
       <PageLayout>
         {!loading && stripeSubscription && stripeSubscription.active ? (
           <Component {...props} />
@@ -36,7 +38,7 @@ const SubscriptionAuthRouter = ({
           <Redirect to="/add-subscription" />
         ) : null}
       </PageLayout>
-    </Helmet>
+    </>
   );
 };
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
In the web subscription module the `Auth` and `AddSubscription` containers are rendered inside of a `Helmet` component. This is causing the pages to render inside of the `<head>` tags of the page.

There isn't an error message being thrown but the pages are blank when you navigate to them. To reproduce follow the steps for stripe set up and navigate to the subscription pages.
...

**How did you fix it?**
Moved the contents of the pages outside of `Helmet`
...
