### PR TITLE
Ant Design RenderSelect Issue

### DIFF
--- a/modules/forms/client-react/FieldAdapter.jsx
+++ b/modules/forms/client-react/FieldAdapter.jsx
@@ -26,11 +26,12 @@ class FieldAdapter extends Component {
   }
 
   onChange = e => {
-    const { onChange } = this.props;
+    const { formik, onChange } = this.props;
+
     if (onChange) {
       onChange(e.target.value, e);
     } else {
-      this.props.formik.handleChange(e);
+      formik.handleChange(e);
     }
   };
 

--- a/modules/look/client-react/ui-antd/components/Option.jsx
+++ b/modules/look/client-react/ui-antd/components/Option.jsx
@@ -1,15 +1,5 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-//import { Select } from 'antd';
+import { Select } from 'antd';
 
-//const ADOption = Select.Option;
+const { Option: ADOption } = Select;
 
-const Option = ({ children, ...props }) => {
-  return <option {...props}>{children}</option>;
-};
-
-Option.propTypes = {
-  children: PropTypes.node
-};
-
-export default Option;
+export default ADOption;

--- a/modules/look/client-react/ui-antd/components/RenderSelect.jsx
+++ b/modules/look/client-react/ui-antd/components/RenderSelect.jsx
@@ -1,32 +1,47 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Form } from 'antd';
+import Select from './Select';
 
 const FormItem = Form.Item;
 
-const RenderField = ({ input, label, type, children, meta: { touched, error } }) => {
+const RenderSelect = props => {
+  const {
+    input,
+    label,
+    type,
+    children,
+    meta: { touched, error }
+  } = props;
   let validateStatus = '';
   if (touched && error) {
     validateStatus = 'error';
   }
 
+  const onChange = value => {
+    const { formik, name } = props;
+    formik.handleChange({ target: { value, name } });
+  };
+
   return (
     <FormItem label={label} validateStatus={validateStatus} help={error}>
       <div>
-        <select {...input} type={type}>
+        <Select {...input} type={type} onChange={onChange}>
           {children}
-        </select>
+        </Select>
       </div>
     </FormItem>
   );
 };
 
-RenderField.propTypes = {
+RenderSelect.propTypes = {
+  formik: PropTypes.object.isRequired,
   input: PropTypes.object,
   label: PropTypes.string,
   type: PropTypes.string,
   meta: PropTypes.object,
+  name: PropTypes.string.isRequired,
   children: PropTypes.node
 };
 
-export default RenderField;
+export default RenderSelect;

--- a/modules/look/client-react/ui-antd/components/Select.jsx
+++ b/modules/look/client-react/ui-antd/components/Select.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Select as ADSelect } from 'antd';
 
 const Select = ({ children, ...props }) => {
-  return <select {...props}>{children}</select>;
+  return <ADSelect {...props}>{children}</ADSelect>;
 };
 
 Select.propTypes = {


### PR DESCRIPTION
**What's the problem this PR addresses?**
The RenderSelect for Ant Design on master uses the native HTML element. Consequently, it isn't styled with Ant Design.

![current_master_2019-12-22 18-54-30 2019-12-22 18_54_43](https://user-images.githubusercontent.com/18373573/71329072-2a606c00-24ee-11ea-8b94-88bc43d34048.gif)

Reactstrap [Form](https://reactstrap.github.io/components/form/) Input component with type `select` onChange receives an event. However, Ant Design [Select](https://ant.design/components/select/) component onChange receives a string value. 

...

**How did you fix it?**
To avoid modifying behavior in FieldAdapter, which is agnostic of UI library (excluding mobile vs non-mobile), I've passed an onChange func that provides a mocked event to the formik handleChange function. Thoughts?

![after_2019-12-22 18-44-47 2019-12-22 18_45_38](https://user-images.githubusercontent.com/18373573/71329078-4b28c180-24ee-11ea-8fd8-ab0d25095855.gif)

This avoids any impact on the existing reactstrap Input component.
![bootstrap_after_2019-12-22 18-47-19 2019-12-22 18_47_38](https://user-images.githubusercontent.com/18373573/71329092-790e0600-24ee-11ea-86b5-1eb2a9ea881c.gif)

...
