### PR TITLE
Migrating from apollo-link-state

### DIFF
--- a/modules/core/common/createApolloClient.ts
+++ b/modules/core/common/createApolloClient.ts
@@ -2,7 +2,7 @@ import fetch from 'isomorphic-unfetch';
 import { getOperationAST } from 'graphql';
 import { BatchHttpLink } from 'apollo-link-batch-http';
 import { ApolloLink } from 'apollo-link';
-import { withClientState } from 'apollo-link-state';
+// import { withClientState } from 'apollo-link-state';
 import { WebSocketLink } from 'apollo-link-ws';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { LoggingLink } from 'apollo-logger';
@@ -116,11 +116,11 @@ const createApolloClient = ({
     );
   }
 
-  const linkState = withClientState({ ...clientResolvers, cache });
+  // const linkState = withClientState({ ...clientResolvers, cache });
 
   const allLinks = [
     ...(createLink ? createLink.map((create: any) => create(getApolloClient)) : []),
-    linkState,
+    // linkState,
     apiLink
   ];
 
@@ -153,7 +153,13 @@ const createApolloClient = ({
   const client = new ApolloClient(clientParams);
   if (cache.constructor.name !== 'OverrideCache') {
     // Restore Apollo Link State defaults only if we don't use `apollo-cache-router`
-    client.onResetStore((linkState as any).writeDefaults);
+    // client.onResetStore((linkState as any).writeDefaults);
+
+    localCache.writeData({
+      data: {
+        ...clientResolvers.defaults
+      }
+    });
   }
 
   if (typeof window !== 'undefined' && window.__APOLLO_STATE__) {

--- a/modules/user/client-react/containers/Users.web.jsx
+++ b/modules/user/client-react/containers/Users.web.jsx
@@ -22,6 +22,7 @@ import {
 
 const Users = props => {
   const { t, updateQuery, subscribeToMore } = props;
+  console.log('props.filter:', props.filter);
   const filter = { isActive: true };
   const usersUpdated = useUsersWithSubscription(subscribeToMore, filter);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
I am trying to migrate from `apollo-link-state`, to fix `default` state not being set on `ssr`.

When this kit migrated to `apollo-client` 3.0 (#1134), `default` state was not set on `ssr`. Workaround for this was to set it in code and pass it to components manualy -> https://github.com/sysgears/apollo-universal-starter-kit/pull/1134/files#diff-1c960d0cc9e1d13dca0e9950e18e5f4eR25.

Apollo docs, state that  `apollo-link-state` is no longer needed and can be removed like this:
https://www.apollographql.com/docs/react/v2.5/essentials/local-state/#migrating-from-apollo-link-state

It also states that `defaults` are no longer supported and `cache.writeData` should be used to set it.

**How did you fix it?**
I followed the migration guide and removed `withClientState` and called `cache.writeData` , to set default data, but it does not seem to work. Now even when code gets regenerated on client side, local state is not working.

I `console.log`  `props.filter` on `/users` route, to test this out.

@larixer Could you please take a look what I am doing wrong and if you have any suggestions how to fix this?
