### PR TITLE
Correction for Angular frontend execute command

### DIFF
--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -61,7 +61,7 @@ that all opened tabs are updated simultaneously.
 **NOTE**: Apollo Universal Starter Kit provides React, Angular and Vue frontends.
 
 To run Angular frontend execute:
-`yarn watch:android`
+`yarn watch:angular`
 
 To run Vue frontend execute:
 `yarn watch:vue`


### PR DESCRIPTION
**What's the problem this PR addresses?**
The command for `Angular frontend execute` is wrongly typed

