### PR TITLE
Add EMAIL_SENDER for mailer

### DIFF
--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -126,6 +126,9 @@ the validation link will be sent to Ethereal, _not_ to the real users.
 | EMAIL_HOST     | mailboxExample.example.com |
 | EMAIL_PASSWORD | examplePassword            |
 | EMAIL_USER     | example@example.com        |
+| EMAIL_SENDER   | example@example.com        |
+
+By default Apollo Universal Starter Kit uses `EMAIL_SENDER` as the `from` e-mail address for all mail sent. It will fall back to `EMAIL_USER` if `EMAIL_SENDER` is not set.
 
 6. Set a proper value for the server website URL in `WEBSITE_URL` environment variable or inside `packages/server/build.config.js` to match your production setup.
 

--- a/modules/contact/server-ts/resolvers.ts
+++ b/modules/contact/server-ts/resolvers.ts
@@ -24,7 +24,7 @@ export default () => ({
       try {
         await mailer.sendMail({
           from: input.email,
-          to: process.env.EMAIL_USER,
+          to: process.env.EMAIL_SENDER || process.env.EMAIL_USER,
           subject: 'New email through contact us page',
           html: `<p>${input.name} is sending the following message.</p><p>${input.content}</p>`
         });

--- a/modules/payments/server-ts/stripe/subscription/webhook.ts
+++ b/modules/payments/server-ts/stripe/subscription/webhook.ts
@@ -21,7 +21,7 @@ const sendEmailToUser = async (userId: number, subject: string, html: string) =>
   const { email }: any = await User.getUser(userId);
 
   mailer.sendMail({
-    from: `${settings.app.name} <${process.env.EMAIL_USER}>`,
+    from: `${settings.app.name} <${process.env.EMAIL_SENDER || process.env.EMAIL_USER}>`,
     to: email,
     subject,
     html

--- a/modules/user/server-ts/password/resolvers.js
+++ b/modules/user/server-ts/password/resolvers.js
@@ -72,7 +72,7 @@ export default () => ({
           const encodedToken = Buffer.from(emailToken).toString('base64');
           const url = `${__WEBSITE_URL__}/confirmation/${encodedToken}`;
           mailer.sendMail({
-            from: `${settings.app.name} <${process.env.EMAIL_USER}>`,
+            from: `${settings.app.name} <${process.env.EMAIL_SENDER || process.env.EMAIL_USER}>`,
             to: user.email,
             subject: 'Confirm Email',
             html: `<p>Hi, ${user.username}!</p>
@@ -101,7 +101,7 @@ export default () => ({
               const encodedToken = Buffer.from(emailToken).toString('base64');
               const url = `${__WEBSITE_URL__}/reset-password/${encodedToken}`;
               mailer.sendMail({
-                from: `${settings.app.name} <${process.env.EMAIL_USER}>`,
+                from: `${settings.app.name} <${process.env.EMAIL_SENDER || process.env.EMAIL_USER}>`,
                 to: user.email,
                 subject: 'Reset Password',
                 html: `Please click this link to reset your password: <a href="${url}">${url}</a>`
@@ -143,7 +143,7 @@ export default () => ({
         const url = `${__WEBSITE_URL__}/profile`;
         if (mailer && settings.auth.password.sendPasswordChangesEmail) {
           mailer.sendMail({
-            from: `${settings.app.name} <${process.env.EMAIL_USER}>`,
+            from: `${settings.app.name} <${process.env.EMAIL_SENDER || process.env.EMAIL_USER}>`,
             to: user.email,
             subject: 'Your Password Has Been Updated',
             html: `<p>As you requested, your account password has been updated.</p>

--- a/modules/user/server-ts/resolvers.js
+++ b/modules/user/server-ts/resolvers.js
@@ -124,7 +124,7 @@ export default pubsub => ({
               const encodedToken = Buffer.from(emailToken).toString('base64');
               const url = `${__WEBSITE_URL__}/confirmation/${encodedToken}`;
               mailer.sendMail({
-                from: `${app.name} <${process.env.EMAIL_USER}>`,
+                from: `${app.name} <${process.env.EMAIL_SENDER || process.env.EMAIL_USER}>`,
                 to: user.email,
                 subject: 'Your account has been created',
                 html: `<p>Hi, ${user.username}!</p>
@@ -189,7 +189,7 @@ export default pubsub => ({
             const url = `${__WEBSITE_URL__}/profile`;
 
             mailer.sendMail({
-              from: `${settings.app.name} <${process.env.EMAIL_USER}>`,
+              from: `${settings.app.name} <${process.env.EMAIL_SENDER || process.env.EMAIL_USER}>`,
               to: input.email,
               subject: 'Your Password Has Been Updated',
               html: `<p>Your account password has been updated.</p>


### PR DESCRIPTION
**What's the problem this PR addresses?**

The user that you login to your SMTP provider with is not always the same as the `from` address that you’d like to use when mail is sent to users.

**How did you fix it?**

Added new environmental variable for `EMAIL_SENDER` with fallback to `EMAIL_USER`
