### PR TITLE
Fix mysql SSL issue

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -6,11 +6,16 @@ const db = {
     socketPath: process.env.DB_SOCKET_PATH,
     password: process.env.DB_PASSWORD,
     database: process.env.DB_DATABASE,
-    ssl: process.env.DB_SSL,
     multipleStatements: true,
     charset: 'utf8'
   }
 };
+
+const ssl = (process.env.DB_SSL || '').toLowerCase();
+
+if (['true', 'false'].includes(ssl)) {
+  db.connection.ssl = ssl === 'true' ? true : false;
+}
 
 const path = require('path');
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

The mySQL driver doesn't like string values for the `DB_SSL` environmental key.

**How did you fix it?**

Make sure to convert the value from `"true"` or `"false"` only and pass it onto the config properly. Don't set the `ssl` param unless the environmental variable is specifically set.
