### PR TITLE
Adds dynamic loading of yarn plugins

### DIFF
--- a/.pmm.js
+++ b/.pmm.js
@@ -14,7 +14,7 @@ const BERRY_URL = `https://raw.githubusercontent.com/yarnpkg/berry/%40yarnpkg/cl
 const YARN_DIR = path.join(__dirname, '.yarn');
 const RELEASES_DIR = path.join(YARN_DIR, 'releases');
 const PLUGIN_DIR = path.join(YARN_DIR, 'plugins');
-const BERRY_FILE = path.join(RELEASES_DIR, `yarn-${REQUESTED_VERSION}.js`);
+const BERRY_FILE = path.join(RELEASES_DIR, `yarn-${REQUESTED_VERSION}.cjs`);
 
 let stats;
 try {

--- a/.pmm.js
+++ b/.pmm.js
@@ -6,7 +6,7 @@ const os = require('os');
 const getPluginUrl = plugin => `https://raw.githubusercontent.com/yarnpkg/berry/master/packages/plugin-${plugin}/bin/%40yarnpkg/plugin-${plugin}.js`
 
 const REQUESTED_VERSION = require('./package.json').pm.split('@')[1];
-const PLUGIN_LIST = fs.readFileSync('./.yarnrc.yml', 'utf-8')
+const PLUGIN_LIST = fs.readFileSync(path.join(__dirname, '.yarnrc.yml'), 'utf-8')
   .split('\n')
   .filter(line => line.includes('.yarn/plugins/@yarnpkg/plugin-'))
   .map(line => line.replace(/^.*\.yarn\/plugins\/@yarnpkg\/plugin-(.*)\.cjs$/, '$1'));

--- a/.pmm.js
+++ b/.pmm.js
@@ -6,22 +6,25 @@ const os = require('os');
 const getPluginUrl = plugin => `https://raw.githubusercontent.com/yarnpkg/berry/master/packages/plugin-${plugin}/bin/%40yarnpkg/plugin-${plugin}.js`
 
 const REQUESTED_VERSION = require('./package.json').pm.split('@')[1];
-const PLUGIN_LIST = fs.readFileSync(path.join(__dirname, '.yarnrc.yml'), 'utf-8')
+const YARNRC_YML_PATH = path.join(__dirname, '.yarnrc.yml');
+const PLUGIN_LIST = !fs.existsSync(YARNRC_YML_PATH) ? [] : fs.readFileSync(YARNRC_YML_PATH, 'utf-8')
   .split('\n')
   .filter(line => line.includes('.yarn/plugins/@yarnpkg/plugin-'))
   .map(line => line.replace(/^.*\.yarn\/plugins\/@yarnpkg\/plugin-(.*)\.cjs$/, '$1'));
-const BERRY_URL = `https://raw.githubusercontent.com/yarnpkg/berry/%40yarnpkg/cli/${REQUESTED_VERSION}/packages/yarnpkg-cli/bin/yarn.js`;
+const YARN_URL = /^[0,1]\..*$/.test(REQUESTED_VERSION) ?
+  `https://github.com/yarnpkg/yarn/releases/download/v${REQUESTED_VERSION}/yarn-${REQUESTED_VERSION}.js` :
+  `https://raw.githubusercontent.com/yarnpkg/berry/%40yarnpkg/cli/${REQUESTED_VERSION}/packages/yarnpkg-cli/bin/yarn.js`;
 const YARN_DIR = path.join(__dirname, '.yarn');
 const RELEASES_DIR = path.join(YARN_DIR, 'releases');
 const PLUGIN_DIR = path.join(YARN_DIR, 'plugins');
-const BERRY_FILE = path.join(RELEASES_DIR, `yarn-${REQUESTED_VERSION}.cjs`);
+const YARN_BINARY = path.join(RELEASES_DIR, `yarn-${REQUESTED_VERSION}.cjs`);
 
 let stats;
 try {
   stats = fs.statSync(RELEASES_DIR);
 } catch (e) {}
-const CURRENT_BERRY_FILENAME = !stats ? null : fs.readdirSync(RELEASES_DIR)[0];
-const CURRENT_VERSION = !stats ? null : path.basename(CURRENT_BERRY_FILENAME).slice(0, -path.extname(CURRENT_BERRY_FILENAME).length).replace('yarn-', '');
+const CURRENT_YARN_BINARYNAME = !stats ? null : fs.readdirSync(RELEASES_DIR)[0];
+const CURRENT_VERSION = !stats ? null : path.basename(CURRENT_YARN_BINARYNAME).slice(0, -path.extname(CURRENT_YARN_BINARYNAME).length).replace('yarn-', '');
 
 const launchBerry = () => {
   const args = [];
@@ -39,22 +42,27 @@ const launchBerry = () => {
   }
   process.argv = args;
   delete process.env.YARN_PRODUCTION;
-  require(BERRY_FILE);
+  require(YARN_BINARY);
 }
 
 const downloadFile = async (filePath, url) => {
   return new Promise((resolve, reject) => {
-    const file = fs.createWriteStream(filePath);
-
-    const request = https.get(url, response => {
-      response.pipe(file);
-      file.on('finish', () => {
-        resolve();
-      });
+    const request = https.get(url, res => {
+      if (res.statusCode === 301 || res.statusCode === 302) {
+        downloadFile(filePath, res.headers.location).then(resolve).catch(reject);
+      } else if (res.statusCode !== 200) {
+        reject(`Error downloading ${url}, status: ${res.statusCode}`)
+      } else {
+        const file = fs.createWriteStream(filePath);
+        res.pipe(file);
+        file.on('finish', () => {
+            resolve();
+        });
+      }
     }).on('error', err => {
+      console.log(err);
       fs.unlink(filePath);
-      console.err(err);
-      reject();
+      reject(err);
     });
   });
 }
@@ -62,14 +70,14 @@ const downloadFile = async (filePath, url) => {
 const promises = []
 
 if (CURRENT_VERSION !== REQUESTED_VERSION) {
-  if (CURRENT_BERRY_FILENAME) {
+  if (CURRENT_YARN_BINARYNAME) {
     fs.rmdirSync(RELEASES_DIR, { recursive: true });
     fs.rmdirSync(PLUGIN_DIR, { recursive: true });
   }
 
   fs.mkdirSync(RELEASES_DIR, { recursive: true });
 
-  promises.push(downloadFile(BERRY_FILE, BERRY_URL));
+  promises.push(downloadFile(YARN_BINARY, YARN_URL));
 }
 
 for (const plugin of PLUGIN_LIST) {
@@ -92,6 +100,10 @@ if (PLUGIN_LIST.length === 0) {
 }
 
 (async () => {
-  await Promise.all(promises);
-  launchBerry();
+  try {
+    await Promise.all(promises);
+    launchBerry();
+  } catch (err) {
+    console.log(err);
+  }
 })();

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,15 @@
-yarnPath: .pmm.js
-nodeLinker: node-modules
-enableGlobalCache: true
 compressionLevel: 0
+
+enableGlobalCache: true
+
 lockfileFilename: yarn2.lock
+
+nodeLinker: node-modules
+
+plugins:
+  - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
+    spec: "@yarnpkg/plugin-workspace-tools"
+  - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
+    spec: "@yarnpkg/plugin-interactive-tools"
+
+yarnPath: .pmm.js


### PR DESCRIPTION
**What's the problem this PR addresses?**

This PR adds support for dynamic downloading of Yarn 2 plugins

**How did you fix it?**

PMM scripts now consults the `.yarnrc.yml` for plugin string and downloads Yarn 2 plugins if they are missing
